### PR TITLE
Use `prototype` instead of `this`

### DIFF
--- a/src/@CatchBodyScope.js
+++ b/src/@CatchBodyScope.js
@@ -1,6 +1,6 @@
 function CatchBodyScope(sParent) {
   LexicalScope.call(this, sParent, ST_CATCH|ST_BODY);
-  
+
   this.paramList = new SortedObj();
   this.hasSimpleList = true;
   this.catchVarName = "";

--- a/src/@ClassScope.js
+++ b/src/@ClassScope.js
@@ -1,6 +1,6 @@
 function ClassScope(sParent, sType) {
   Scope.call(this, sParent, sType|ST_CLS);
-  
+
   this.synthCLSPName = "";
   this.synthSuperName = "";
   this.synthCLSName = "";

--- a/src/@ErrorString.js
+++ b/src/@ErrorString.js
@@ -6,7 +6,7 @@ function eof_rcurly(str, i) {
   if (i >= str.length)
     ASSERT.call(this, false, 'reached eof before a }');
 
-  return str.charCodeAt(i) === CH_RCURLY; 
+  return str.charCodeAt(i) === CH_RCURLY;
 }
 
 function readTemplate(str, i) {
@@ -32,7 +32,7 @@ ErrorString.from = function(str) {
     }
     else
       elem += str.charAt(i);
-    
+
     i++;
   }
   if (elem.length)

--- a/src/@GlobalScope.js
+++ b/src/@GlobalScope.js
@@ -1,4 +1,4 @@
 function GlobalScope() {
-  Scope.call(this, null, ST_GLOBAL);  
+  Scope.call(this, null, ST_GLOBAL);
 }
 

--- a/src/@LexicalScope.js
+++ b/src/@LexicalScope.js
@@ -3,7 +3,7 @@ function LexicalScope(sParent, sType) {
 
   this.synthName = "";
   this.childBindings = null;
-  
+
   var surroundingCatch =
     sParent.isCatchBody() ?
       sParent :

--- a/src/@Parser.js
+++ b/src/@Parser.js
@@ -21,7 +21,7 @@ var Parser = function (src, o) {
   this.li = 1;
   this.col = 0;
   this.c = 0;
-  
+
   this.canBeStatement = false;
   this.foundStatement = false;
   this.scopeFlags = 0;
@@ -35,9 +35,9 @@ var Parser = function (src, o) {
 
   this.scope = null;
   this.directive = DIR_NONE;
-  
+
   this.declMode = DECL_NONE;
- 
+
   // TODO:eliminate
   this.pendingExprHead = null;
 
@@ -54,7 +54,7 @@ var Parser = function (src, o) {
   // "pin" location; for errors that might not have been precisely cause by a syntax node, like:
   // function l() { '\12'; 'use strict' }
   //                 ^
-  // 
+  //
   // for (a i\u0074 e) break;
   //         ^
   //

--- a/src/@Scope.js
+++ b/src/@Scope.js
@@ -4,7 +4,7 @@ function Scope(sParent, sType) {
   this.scs = this.isConcrete() ?
     this :
     this.parent.scs;
-  
+
   this.defs = new SortedObj();
   this.refs = new SortedObj();
 
@@ -14,7 +14,7 @@ function Scope(sParent, sType) {
     this.allowed &= ~SA_CALLSUP;
 
   this.labelTracker = new LabelTracker();
-  this.allNames = this.parent ? 
+  this.allNames = this.parent ?
     this.parent.allNames :
     new SortedObj();
 

--- a/src/@Template.js
+++ b/src/@Template.js
@@ -12,12 +12,12 @@ function readParen(str, i, eof) {
     case CH_LESS_THAN: elem += '('; break;
     case CH_RPAREN: return elem;
     default:
-      ASSERT.call(this, false, 
+      ASSERT.call(this, false,
         'invalid character at index '+i+' -- "'+str.charAt(i)+'"');
     }
     i++;
   }
-  ASSERT.call(this, false, 
+  ASSERT.call(this, false,
     'reached eof before any ")" was found');
 }
 
@@ -52,8 +52,8 @@ Template.from = function(str, i, eof) {
       i++;
       elem += readParen(str, i, eof);
       if (elem.length === 0)
-        needDot = true; 
-      
+        needDot = true;
+
       i += elem.length + 1; // length + ')'.length
       continue;
     }
@@ -63,7 +63,7 @@ Template.from = function(str, i, eof) {
     i++;
   }
 
-  pendingDot && ASSERT.call(this, false, 
+  pendingDot && ASSERT.call(this, false,
     'unexpected ' + (!eof(str, i) ? 'dot (index='+i+')' : 'eof'));
 
   if (needDot || elem.length > 0)

--- a/src/@Transformer.js
+++ b/src/@Transformer.js
@@ -18,7 +18,7 @@
 // the fact that l([b] = 12) is transformed _after_ `[a = l([b] = 12)] = 120` is done getting transformed, due to the way
 // transformation works:
 //   transform( [a=l([b]=12)]=120 ): #t = arrIter(120), a = unornull(#t1 = #t.get) ? l([b] = 12) : #t1, #t.val
-// 
+//
 // when the above transform is finished, all temps are released, and the transformed assignment is fed into
 // the emitter; when the emitter encounters l([b] = 12),  it reallocate some of the temps previously alloctated, and that is where
 // the clash is going to happen.

--- a/src/assig-helpers@Parser.js
+++ b/src/assig-helpers@Parser.js
@@ -1,4 +1,4 @@
-this .ensureSimpAssig_soft = function(head) {
+Parser.prototype.ensureSimpAssig_soft = function(head) {
   switch(head.type) {
   case 'Identifier':
     if ( this.scope.insideStrict() && arguments_or_eval(head.name) )
@@ -13,7 +13,7 @@ this .ensureSimpAssig_soft = function(head) {
   }
 };
 
-this.ensureSpreadToRestArgument_soft = function(head) {
+Parser.prototype.ensureSpreadToRestArgument_soft = function(head) {
   return head.type !== 'AssignmentExpression';
 };
 

--- a/src/comtok@Parser.js
+++ b/src/comtok@Parser.js
@@ -25,7 +25,7 @@ this.onComment = function(isBlock,c0,loc0,c,loc) {
     start_val = c0;
     end_val = c;
     loc0.column -= stepBack;
-  
+
   }
 
   var comment = this.onComment_,
@@ -79,7 +79,7 @@ this.onToken = function(token) {
       tval = this.ltraw;
       switch (tval) {
       case 'static':
-        if (!this.scope.insideStrict()) 
+        if (!this.scope.insideStrict())
           break;
       case 'in':
       case 'instanceof':

--- a/src/comtok@Parser.js
+++ b/src/comtok@Parser.js
@@ -1,4 +1,4 @@
-this.onComment = function(isBlock,c0,loc0,c,loc) {
+Parser.prototype.onComment = function(isBlock,c0,loc0,c,loc) {
   var start_comment = -1, end_comment = -1;
   var start_val = -1, end_val = -1;
   if (isBlock) {
@@ -45,7 +45,7 @@ this.onComment = function(isBlock,c0,loc0,c,loc) {
   }
 };
 
-this.onToken = function(token) {
+Parser.prototype.onToken = function(token) {
   if (token === null) {
     var ttype = "", tval = "";
     switch (this.lttype) {
@@ -119,7 +119,7 @@ this.onToken = function(token) {
 
 };
 
-this.onToken_kw = function(c0,loc0,val) {
+Parser.prototype.onToken_kw = function(c0,loc0,val) {
   // TODO: val must=== raw
   this.onToken({
     type: 'Keyword',

--- a/src/constants.js
+++ b/src/constants.js
@@ -124,7 +124,7 @@ var CTX_NONE = 0,
     CTX_PARPAT_ERR = CTX_HAS_A_PARAM_ERR|CTX_HAS_AN_ASSIG_ERR|CTX_HAS_A_SIMPLE_ERR,
     CTX_TOP = CTX_PAT|CTX_NO_SIMPLE_ERR;
 
-// TODO: order matters in the first few declarations below, mostly due to a 
+// TODO: order matters in the first few declarations below, mostly due to a
 // slight performance gain in parseFunc, where MEM_CONSTRUCTOR and MEM_SUPER in `flags` are
 // getting added to the current scope flags.
 // the ordering is also to make the relevant value sets (i.e., SCOPE_FLAG_* and MEM_*)
@@ -140,7 +140,7 @@ var ARGLEN_GET = 0,
     ARGLEN_ANY = -1;
 
 var DECL_NONE = 0;
-var DECL_NOT_FOUND = 
+var DECL_NOT_FOUND =
   // #if V
   null;
   // #else

--- a/src/conv-arrow@Parser.js
+++ b/src/conv-arrow@Parser.js
@@ -1,10 +1,10 @@
-this.asArrowFuncArgList = function(argList) {
+Parser.prototype.asArrowFuncArgList = function(argList) {
   var i = 0, list = argList;
   while (i < list.length)
     this.asArrowFuncArg(list[i++]);
 };
 
-this.asArrowFuncArg = function(arg) {
+Parser.prototype.asArrowFuncArg = function(arg) {
   var i = 0, list = null;
   if (arg === this.po)
     this.throwTricky('p', this.pt);

--- a/src/conv-arrow@Parser.js
+++ b/src/conv-arrow@Parser.js
@@ -14,7 +14,7 @@ this.asArrowFuncArg = function(arg) {
     if (this.scope.canAwait() &&
        arg.name === 'await')
       this.err('arrow.param.is.await.in.an.async',{tn:arg});
-     
+
     // TODO: this can also get checked in the scope manager rather than below
     if (this.scope.insideStrict() && arguments_or_eval(arg.name))
       this.err('binding.to.arguments.or.eval',{tn:arg});

--- a/src/conv-assig@Parser.js
+++ b/src/conv-assig@Parser.js
@@ -1,4 +1,4 @@
-this.toAssig = function(head, context) {
+Parser.prototype.toAssig = function(head, context) {
   if (head === this.ao)
     this.throwTricky('a', this.at, this.ae)
 

--- a/src/conv-assig@Parser.js
+++ b/src/conv-assig@Parser.js
@@ -72,7 +72,7 @@ this.toAssig = function(head, context) {
 
   default:
     this.err('not.assignable',{tn:core(head)});
- 
+
   }
 };
 

--- a/src/core@CatchBodyScope.js
+++ b/src/core@CatchBodyScope.js
@@ -1,4 +1,4 @@
-this.findCatchVar_m = function(mname) {
+CatchBodyScope.prototype.findCatchVar_m = function(mname) {
   var varDecl = this.findDecl_m(mname);
   if (varDecl && varDecl.isCatchVar())
     return varDecl;

--- a/src/core@Decl.js
+++ b/src/core@Decl.js
@@ -1,15 +1,15 @@
-this.isHoistedInItsScope = function() {
+Decl.prototype.isHoistedInItsScope = function() {
   return this.mode & DM_FUNCTION;
 };
 
-this.isVarLike = function() {
+Decl.prototype.isVarLike = function() {
   if (this.isFunc())
     return this.ref.scope.isConcrete();
   return this.isVName() ||
          this.isFuncArg();
 };
 
-this.isLexical = function() {
+Decl.prototype.isLexical = function() {
   if (this.isFunc())
     return this.ref.scope.isLexical();
   return this.isClass() ||
@@ -17,47 +17,47 @@ this.isLexical = function() {
          this.isCName();
 };
 
-this.isTopmostInItsScope = function() {
+Decl.prototype.isTopmostInItsScope = function() {
   return this.isFuncArg() ||
          this.isCatchArg() ||
          this.isHoistedInItsScope() ||
          this.isVarLike();
 };
 
-this.isClass = function() {
+Decl.prototype.isClass = function() {
   return this.mode & DM_CLS;
 };
 
-this.isCatchArg = function() {
+Decl.prototype.isCatchArg = function() {
   return this.mode & DM_CATCHARG;
 };
 
-this.isFunc = function() {
+Decl.prototype.isFunc = function() {
   return this.mode & DM_FUNCTION;
 };
 
-this.isFuncArg = function() {
+Decl.prototype.isFuncArg = function() {
   return this.mode & DM_FNARG;
 };
 
-this.isVName = function() {
+Decl.prototype.isVName = function() {
   return this.mode & DM_VAR;
 };
 
-this.isLName = function() {
+Decl.prototype.isLName = function() {
   return this.mode & DM_LET;
 };
 
-this.isCName = function() {
+Decl.prototype.isCName = function() {
   return this.mode & DM_CONST;
 };
 
-this.isName = function() {
+Decl.prototype.isName = function() {
   return this.mode &
     (DM_VAR|DM_LET|DM_CONST);
 };
 
-this.absorbRef = function(otherRef) {
+Decl.prototype.absorbRef = function(otherRef) {
   ASSERT.call(this, !otherRef.resolved,
     'a resolved reference must not be absorbed by a declref');
 
@@ -78,14 +78,14 @@ this.absorbRef = function(otherRef) {
   return cur;
 };
 
-this.m = function(mode) {
+Decl.prototype.m = function(mode) {
   ASSERT.call(this, this.mode === DM_NONE,
     'can not change mode');
   this.mode = mode;
   return this;
 };
 
-this.r = function(ref) {
+Decl.prototype.r = function(ref) {
   ASSERT.call(this, this.ref === null,
     'can not change ref');
   this.ref = ref;
@@ -93,14 +93,14 @@ this.r = function(ref) {
   return this;
 };
 
-this.n = function(name) {
+Decl.prototype.n = function(name) {
   ASSERT.call(this, this.name === "",
     'can not change name');
   this.name = name;
   return this;
 };
 
-this.s = function(site) {
+Decl.prototype.s = function(site) {
   ASSERT.call(this, this.site === null,
     'can not change site');
   this.site = site;

--- a/src/core@Decl.js
+++ b/src/core@Decl.js
@@ -63,7 +63,7 @@ this.absorbRef = function(otherRef) {
 
   var fromScope = otherRef.scope;
   var cur = this.ref;
-  
+
   if (fromScope.isIndirect()) {
     if (fromScope.isHoisted() &&
         !this.isTopmostInItsScope())

--- a/src/core@Emitter.js
+++ b/src/core@Emitter.js
@@ -1,18 +1,18 @@
-this.indent = function() {
+Emitter.prototype.indent = function() {
   this.indentLevel++;
 };
 
-this.i = function() {
+Emitter.prototype.i = function() {
   this.indent();
   return this;
 };
 
-this.l = function() {
+Emitter.prototype.l = function() {
   this.startLine();
   return this;
 };
 
-this.emitHead =
+Emitter.prototype.emitHead =
 function(n, prec, flags) {
   switch (n.type) {
   case 'ConditionalExpression':
@@ -33,23 +33,23 @@ function(n, prec, flags) {
   }
 };
 
-this.eH = function(n, prec, flags) {
+Emitter.prototype.eH = function(n, prec, flags) {
   this.emitHead(n, prec, flags);
   return this;
 };
 
-this.emitAny = function(n, prec, startStmt) {
+Emitter.prototype.emitAny = function(n, prec, startStmt) {
   if (HAS.call(Emitters, n.type))
     return Emitters[n.type].call(this, n, prec, startStmt);
   this.err('unknow.node');
 };
 
-this.eA = function(n, prec, startStmt) {
+Emitter.prototype.eA = function(n, prec, startStmt) {
   this.emitAny(n, prec, startStmt);
   return this;
 };
 
-this.emitNonSeq = function(n, prec, flags) {
+Emitter.prototype.emitNonSeq = function(n, prec, flags) {
   var paren =
     n.type === 'SequenceExpression' ||
     n.type === 'SynthSequenceExpression';
@@ -58,12 +58,12 @@ this.emitNonSeq = function(n, prec, flags) {
   if (paren) this.w(')');
 };
 
-this.eN = function(n, prec, flags) {
+Emitter.prototype.eN = function(n, prec, flags) {
   this.emitNonSeq(n, prec, flags);
   return this;
 };
 
-this.write = function(rawStr) {
+Emitter.prototype.write = function(rawStr) {
   if (this.lineStarted) {
     this.code += this.getOrCreateIndent(this.indentLevel);
     this.lineStarted = false;
@@ -71,25 +71,25 @@ this.write = function(rawStr) {
   this.code += rawStr;
 };
 
-this.w = function(rawStr) {
+Emitter.prototype.w = function(rawStr) {
   this.write(rawStr);
   return this;
 };
 
-this.space = function() {
+Emitter.prototype.space = function() {
   if (this.lineStarted)
     this.err('useless.space');
 
   this.write(' ');
 };
 
-this.s = function() {
+Emitter.prototype.s = function() {
   this.space();
   return this;
 };
 
-this.writeMulti =
-this.wm = function() {
+Emitter.prototype.writeMulti =
+Emitter.prototype.wm = function() {
   var i = 0;
   while (i < arguments.length) {
     var str = arguments[i++];
@@ -102,19 +102,19 @@ this.wm = function() {
   return this;
 };
 
-this.unindent = function() {
+Emitter.prototype.unindent = function() {
   if (this.indentLevel <= 0)
     this.err('unindent.nowidth');
 
   this.indentLevel--;
 };
 
-this.u = function() {
+Emitter.prototype.u = function() {
   this.unindent();
   return this;
 };
 
-this.getOrCreateIndent = function(indentLen) {
+Emitter.prototype.getOrCreateIndent = function(indentLen) {
   var cache = this.indentCache;
   if (indentLen >= cache.length) {
     if (indentLen !== cache.length)
@@ -124,16 +124,16 @@ this.getOrCreateIndent = function(indentLen) {
   return cache[indentLen];
 };
 
-this.startLine = function() {
+Emitter.prototype.startLine = function() {
   this.insertNL();
   this.lineStarted = true;
 };
 
-this.insertNL = function() {
+Emitter.prototype.insertNL = function() {
   this.code += '\n';
 };
 
-this.noWrap = function() {
+Emitter.prototype.noWrap = function() {
   this.noWrap_ = true;
   return this;
 };

--- a/src/core@Emitter.js
+++ b/src/core@Emitter.js
@@ -1,15 +1,15 @@
 this.indent = function() {
-  this.indentLevel++; 
+  this.indentLevel++;
 };
 
 this.i = function() {
   this.indent();
-  return this; 
+  return this;
 };
 
 this.l = function() {
   this.startLine();
-  return this; 
+  return this;
 };
 
 this.emitHead =
@@ -27,7 +27,7 @@ function(n, prec, flags) {
   case 'SynthSequenceExpression':
     this.w('(').eA(n, PREC_NONE, EC_NONE).w(')');
     break;
-  default: 
+  default:
     this.emitAny(n, prec, flags);
     break;
   }
@@ -45,8 +45,8 @@ this.emitAny = function(n, prec, startStmt) {
 };
 
 this.eA = function(n, prec, startStmt) {
-  this.emitAny(n, prec, startStmt); 
-  return this; 
+  this.emitAny(n, prec, startStmt);
+  return this;
 };
 
 this.emitNonSeq = function(n, prec, flags) {

--- a/src/core@ErrorString.js
+++ b/src/core@ErrorString.js
@@ -1,4 +1,4 @@
-this.applyTo = function(obj) {
+ErrorString.prototype.applyTo = function(obj) {
   var errorMessage = "",
       isString = true,
       list = this.stringsAndTemplates,

--- a/src/core@ErrorString.js
+++ b/src/core@ErrorString.js
@@ -9,7 +9,7 @@ this.applyTo = function(obj) {
     e++;
     isString = !isString;
   }
-  
+
   return errorMessage;
 };
 

--- a/src/core@FuncHeadScope.js
+++ b/src/core@FuncHeadScope.js
@@ -1,4 +1,4 @@
-this.verifyForStrictness = function() {
+FuncHeadScope.prototype.verifyForStrictness = function() {
   if (this.firstDup)
     this.parser.err('argsdup');
   if (this.firstNonSimple)
@@ -14,14 +14,14 @@ this.verifyForStrictness = function() {
   }
 };
 
-this.exitUniqueArgs = function() {
+FuncHeadScope.prototype.exitUniqueArgs = function() {
   ASSERT.call(this, this.insideUniqueArgs(),
     'can not unset unique when it has not been set');
 
   this.mode &= ~SM_UNIQUE;
 };
 
-this.enterUniqueArgs = function() {
+FuncHeadScope.prototype.enterUniqueArgs = function() {
   if (this.firstDup)
     this.parser.err('argsdup');
   if (this.insideUniqueArgs())
@@ -30,7 +30,7 @@ this.enterUniqueArgs = function() {
   this.mode |= SM_UNIQUE;
 };
 
-this.absorb = function(parenScope) {
+FuncHeadScope.prototype.absorb = function(parenScope) {
   ASSERT.call(this, this.isArrowComp() && this.isHead(),
     'the only scope allowed to take in a paren is an arrow-head');
   ASSERT.call(this, parenScope.isParen(),
@@ -55,7 +55,7 @@ this.absorb = function(parenScope) {
     list[i++].ref.direct.fw--; // one ref is a decls
 };
 
-this.writeTo = function(emitter) {
+FuncHeadScope.prototype.writeTo = function(emitter) {
   var list = this.paramList, i = 0;
   emitter.w(this.headI+':<arglist type="'+this.typeString()+'">');
   if (list.length !== 0) {

--- a/src/core@Hitmap.js
+++ b/src/core@Hitmap.js
@@ -3,7 +3,7 @@ this.isValidName = function(name) {
 };
 
 this.isValidName_m = function(mname) {
-  return this.validNames === null ? true : 
+  return this.validNames === null ? true :
     this.validNames.has(mname);
 };
 

--- a/src/core@Hitmap.js
+++ b/src/core@Hitmap.js
@@ -1,17 +1,17 @@
-this.isValidName = function(name) {
+Hitmap.prototype.isValidName = function(name) {
   return this.isValidName_m(name+'%');
 };
 
-this.isValidName_m = function(mname) {
+Hitmap.prototype.isValidName_m = function(mname) {
   return this.validNames === null ? true :
     this.validNames.has(mname);
 };
 
-this.set = function(name, value) {
+Hitmap.prototype.set = function(name, value) {
   return this.set_m(name+'%', value);
 };
 
-this.set_m = function(mname, value) {
+Hitmap.prototype.set_m = function(mname, value) {
   ASSERT.call(this, this.isValidName_m(mname),
     'not among the valid names: <' + mname + '>');
   if (!this.names.has(mname))
@@ -24,11 +24,11 @@ this.set_m = function(mname, value) {
   return entry;
 };
 
-this.getOrCreate = this.getoc = function(name) {
+Hitmap.prototype.getOrCreate = this.getoc = function(name) {
   return this.getOrCreate_m(name+'%');
 };
 
-this.getOrCreate_m = this.getoc_m = function(mname) {
+Hitmap.prototype.getOrCreate_m = this.getoc_m = function(mname) {
   ASSERT.call(this, this.isValidName_m(mname),
     'not among the valid names: <' + mname + '>');
   if (!this.names.has(mname))

--- a/src/core@LabelTracker.js
+++ b/src/core@LabelTracker.js
@@ -39,12 +39,12 @@ this.exit = function() {
     target.synthLabel = synthName;
     this.containedLabels[0].push([synthName]);
   }
- 
+
   this.parent && this.parent.takeChildLabels();
 };
 
 this.newSynthLabelName = function(baseLabelName) {
-  baseLabelName = baseLabelName || 
+  baseLabelName = baseLabelName ||
     (baseLabelName === "" ? 'label' : baseLabelName);
   var synthName = baseLabelName, num = 0;
 

--- a/src/core@LabelTracker.js
+++ b/src/core@LabelTracker.js
@@ -1,4 +1,4 @@
-this.addLabel = function(labelName) {
+LabelTracker.prototype.addLabel = function(labelName) {
   ASSERT.call(
     this,
     this.target === null,
@@ -10,12 +10,12 @@ this.addLabel = function(labelName) {
   this.activeLabels.push(labelName);
 };
 
-this.takeChildLabels = function(chlt) {
+LabelTracker.prototype.takeChildLabels = function(chlt) {
   this.containedLabels =
     this.containedLabels.concat(chlt.containedLabels);
 };
 
-this.setLabelTarget = function(target) {
+LabelTracker.prototype.setLabelTarget = function(target) {
   if (target.type !== 'YieldContainer')
     return;
   this.target = target;
@@ -24,7 +24,7 @@ this.setLabelTarget = function(target) {
   this.activeLabels = null;
 };
 
-this.exit = function() {
+LabelTracker.prototype.exit = function() {
   if (this.synthAtExit) {
     ASSERT.call(this, this.target !== null,
       'there must be a target to synthesize a label for.');
@@ -43,7 +43,7 @@ this.exit = function() {
   this.parent && this.parent.takeChildLabels();
 };
 
-this.newSynthLabelName = function(baseLabelName) {
+LabelTracker.prototype.newSynthLabelName = function(baseLabelName) {
   baseLabelName = baseLabelName ||
     (baseLabelName === "" ? 'label' : baseLabelName);
   var synthName = baseLabelName, num = 0;

--- a/src/core@ParenScope.js
+++ b/src/core@ParenScope.js
@@ -1,4 +1,4 @@
-this.dissolve = function() {
+ParenScope.prototype.dissolve = function() {
   var list = this.paramList,
       i = 0,
       ref = null,
@@ -24,7 +24,7 @@ this.dissolve = function() {
   }
 };
 
-this.addPossibleArgument = function(argNode) {
+ParenScope.prototype.addPossibleArgument = function(argNode) {
   var head = null;
 
   if (argNode.type === 'Property')
@@ -72,4 +72,4 @@ this.addPossibleArgument = function(argNode) {
   this.paramList.push(newDecl);
 };
 
-this.finish = function() {};
+ParenScope.prototype.finish = function() {};

--- a/src/core@ParenScope.js
+++ b/src/core@ParenScope.js
@@ -14,7 +14,7 @@ this.dissolve = function() {
     if (ref.resolved)
       ref.resolved = false;
 
-    ref.direct.fw += elem.direct.fw; 
+    ref.direct.fw += elem.direct.fw;
     ref.direct.ex += elem.direct.ex;
 
     ref.indirect.fw += elem.indirect.fw;

--- a/src/core@Ref.js
+++ b/src/core@Ref.js
@@ -1,15 +1,15 @@
-this.resolve = function() {
+Ref.prototype.resolve = function() {
   ASSERT.call(this, !this.resolved,
     'this ref has already been resolved actually');
   this.resolved = true;
   return this;
 };
 
-this.total = function() {
+Ref.prototype.total = function() {
   return this.indirect.total() + this.direct.total();
 };
 
-this.absorb = function(anotherRef) {
+Ref.prototype.absorb = function(anotherRef) {
   ASSERT.call(this, !this.resolved,
     'a resolved reference must absorb through its decl');
   ASSERT.call(this, !anotherRef.resolved,

--- a/src/core@RefCount.js
+++ b/src/core@RefCount.js
@@ -1,3 +1,3 @@
-this.total = function() {
+RefCount.prototype.total = function() {
   return this.fw + this.ex;
 };

--- a/src/core@Scope.js
+++ b/src/core@Scope.js
@@ -1,11 +1,11 @@
-this.calculateParent = function() {
+Scope.prototype.calculateParent = function() {
   if (this.parent.isParen())
     this.parent = this.parent.calculateParen();
 
   return this.parent;
 };
 
-this.calculateAllowedActions = function() {
+Scope.prototype.calculateAllowedActions = function() {
   if (this.isParen())
     return this.parent.allowed;
 
@@ -27,7 +27,7 @@ this.calculateAllowedActions = function() {
   return a;
 };
 
-this.calculateScopeMode = function() {
+Scope.prototype.calculateScopeMode = function() {
   if (this.isParen())
     return this.parent.mode;
 
@@ -53,7 +53,7 @@ this.calculateScopeMode = function() {
   return m;
 };
 
-this.setName = function(name) {
+Scope.prototype.setName = function(name) {
   ASSERT.call(this, this.isExpr(),
     'the current scope is not an expr scope, and can not have a name');
   ASSERT.call(this, this.scopeName === "",

--- a/src/core@SortedObj.js
+++ b/src/core@SortedObj.js
@@ -1,18 +1,18 @@
-this.set = function(name, val) {
+SortedObj.prototype.set = function(name, val) {
   if (!HAS.call(this.obj, name))
     this.keys.push(name);
   return this.obj[name] = val;
 };
 
-this.at = function(i) {
+SortedObj.prototype.at = function(i) {
   return i < this.keys.length ? this.obj[this.keys[i]] : void 0;
 };
 
-this.get = function(name) {
+SortedObj.prototype.get = function(name) {
   return this.obj[name];
 };
 
-this.remove = function(name) {
+SortedObj.prototype.remove = function(name) {
   if (!HAS.call(this.obj, name))
     return false;
   delete this.obj[name];
@@ -31,6 +31,6 @@ this.remove = function(name) {
   return true;
 };
 
-this.has = function(name) {
+SortedObj.prototype.has = function(name) {
   return HAS.call(this.obj, name);
 };

--- a/src/core@SortedObj.js
+++ b/src/core@SortedObj.js
@@ -9,7 +9,7 @@ this.at = function(i) {
 };
 
 this.get = function(name) {
-  return this.obj[name]; 
+  return this.obj[name];
 };
 
 this.remove = function(name) {

--- a/src/core@Template.js
+++ b/src/core@Template.js
@@ -1,7 +1,7 @@
 // TODO: add a mechanism to react to cases where latestVal does not have a property (own or inherited)
 // whose name has the same value as idx
 
-this.applyTo = function(obj, noErrIfUndefNull) {
+Template.prototype.applyTo = function(obj, noErrIfUndefNull) {
   var latestVal = obj, latestIdx = "", list = this.idxList, e = 0;
   while (e < list.length) {
     var idx = list[e];

--- a/src/core@Template.js
+++ b/src/core@Template.js
@@ -15,7 +15,7 @@ this.applyTo = function(obj, noErrIfUndefNull) {
         'is ' + (latestVal !== null ? 'undefined' : 'null')
       );
     }
-    
+
     latestVal = latestVal[idx];
     latestIdx = e;
 

--- a/src/core@Transformer.js
+++ b/src/core@Transformer.js
@@ -1,17 +1,17 @@
-this.y = function(n) {
+Transformer.prototype.y = function(n) {
   return this.inGen ? y(n) : 0;
 };
 
-this.allocTemp = function() {
+Transformer.prototype.allocTemp = function() {
   var id = newTemp(this.currentScope.allocateTemp());
   return id;
 };
 
-this.releaseTemp = this.rl = function(id) {
+Transformer.prototype.releaseTemp = this.rl = function(id) {
   this.currentScope.releaseTemp(id.name);
 };
 
-this.transform = this.tr = function(n, list, isVal) {
+Transformer.prototype.transform = this.tr = function(n, list, isVal) {
   var ntype = n.type;
   switch (ntype) {
     case 'Identifier':
@@ -29,9 +29,9 @@ this.transform = this.tr = function(n, list, isVal) {
   }
 };
 
-this.rlit = function(id) { isTemp(id) && this.rl(id); };
+Transformer.prototype.rlit = function(id) { isTemp(id) && this.rl(id); };
 
-this.save = function(n, list) {
+Transformer.prototype.save = function(n, list) {
   var temp = this.allocTemp();
   push_checked(synth_assig(temp, n), list);
   return temp;

--- a/src/count-yield.js
+++ b/src/count-yield.js
@@ -32,8 +32,8 @@ yList['DoWhileStatement'] =
   function() { return this.y !== -1 ? this.y : this.y = y(this.test) + y(this.body); };
 yList['ForStatement'] =
   function() { return this.y !== -1 ? this.y : this.y = y(this.init) + y(this.test) + y(this.update) + y(this.body); };
-yList['IfStatement'] = 
-yList['ConditionalExpression'] = 
+yList['IfStatement'] =
+yList['ConditionalExpression'] =
   function() { return this.y !== -1 ? this.y : this.y = y(this.test) + y(this.consequent) + y(this.alternate); };
 yList['CallExpression'] =
 yList['NewExpression'] =
@@ -41,9 +41,9 @@ yList['NewExpression'] =
 yList['ClassDeclaration'] =
 yList['ClassExpression'] =
   function() { return this.y !== -1 ? this.y : this.y = y(this.superClass) + y(this.body); };
-yList['CatchClause'] = 
+yList['CatchClause'] =
   function() { return this.y !== -1 ? this.y : this.y = y(this.param) + y(this.body); };
-yList['BlockStatement'] = 
+yList['BlockStatement'] =
 yList['ClassBody'] =
   function() { return this.y !== -1 ? this.y : this.y = yArray(this.body); };
 yList['ThrowStatement'] =
@@ -56,16 +56,16 @@ yList['UpdateExpression'] =
 yList['ObjectExpression'] =
 yList['ObjectPattern'] =
   function() { return this.y !== -1 ? this.y : this.y = yArray(this.properties); };
-yList['BreakStatement'] = 
-yList['EmptyStatement'] = 
-yList['ContinueStatement'] = 
+yList['BreakStatement'] =
+yList['EmptyStatement'] =
+yList['ContinueStatement'] =
 yList['DebuggerStatement'] =
-yList['Identifier'] = 
-yList['Literal'] = 
+yList['Identifier'] =
+yList['Literal'] =
 yList['FunctionDeclaration'] =
 yList['FunctionExpression'] =
 yList['ArrowFunctionExpression'] =
-yList['ThisExpression'] = 
+yList['ThisExpression'] =
 yList['Super'] =
 yList['TemplateElement'] =
   function() { return -1; };
@@ -81,24 +81,24 @@ yList['ImportDefaultSpecifier'] =
 yList['ImportNamespaceSpecifier'] =
 yList['ImportSpecifier'] =
   function() { return -1; };
-yList['SwitchCase'] = 
+yList['SwitchCase'] =
   function() { return this.y !== -1 ? this.y : this.y = y(this.test) + yArray(this.consequent); };
-yList['SwitchStatement'] = 
+yList['SwitchStatement'] =
   function() { return this.y !== -1 ? this.y : this.y = y(this.discriminant) + yArray(this.cases); };
 yList['LabeledStatement'] =
   function() { return y(this.body); };
-yList['MemberExpression'] = 
+yList['MemberExpression'] =
   function() { return this.y !== -1 ? this.y : this.y = this.computed ? y(this.object) + y(this.property) : y(this.object); };
 yList['MetaProperty'] =
   function() { return -1; };
-yList['Program'] = yList['BlockStatement']; 
+yList['Program'] = yList['BlockStatement'];
 
-function kv() { return this.y !== -1 ? this.y : this.y = this.computed ? y(this.key) + y(this.value) : y(this.value); }; 
+function kv() { return this.y !== -1 ? this.y : this.y = this.computed ? y(this.key) + y(this.value) : y(this.value); };
 
 yList['Property'] =
 yList['AssignmentProperty'] = kv;
 yList['MethodDefinition'] = kv;
-yList['SequenceExpression'] = 
+yList['SequenceExpression'] =
 yList['TemplateLiteral'] =
   function() { return this.y !== -1 ? this.y : this.y = yArray(this.expressions); };
 yList['TaggedTemplateExpression'] =
@@ -110,8 +110,8 @@ yList['VariableDeclaration'] =
 yList['VariableDeclarator'] =
   function() { return this.y !== -1 ? this.y : this.y = y(this.id) + y(this.init); };
 yList['WithStatement'] =
-  function() { return this.y !== -1 ? this.y : this.y = y(this.object) + y(this.body); }; 
-yList['YieldExpression'] = 
+  function() { return this.y !== -1 ? this.y : this.y = y(this.object) + y(this.body); };
+yList['YieldExpression'] =
   function() { return this.y !== -1 ? this.y : this.y = 1 + y(this.argument); };
 yList['WhileStatement'] =
   function() { return this.y !== -1 ? this.y : this.y = y(this.test) + y(this.body); };

--- a/src/ctype.js
+++ b/src/ctype.js
@@ -19,7 +19,7 @@ function isIDBody (c) {
     (c <= CH_9 && c >= CH_0) ||
     c === CH_UNDERLINE ||
     c === CH_$ ||
-    (IDC_[c >> D_INTBITLEN] & (1 << (c & M_INTBITLEN))) 
+    (IDC_[c >> D_INTBITLEN] & (1 << (c & M_INTBITLEN)))
   );
 }
 

--- a/src/decl@Scope.js
+++ b/src/decl@Scope.js
@@ -1,8 +1,8 @@
-this.declare = function(name, mode) {
+Scope.prototype.declare = function(name, mode) {
   return this.declare_m(_m(name), mode);
 };
 
-this.declare_m = function(mname, mode) {
+Scope.prototype.declare_m = function(mname, mode) {
   if (mode & DM_LET)
     return this.let_m(mname, mode);
   if (mode & DM_FUNCTION)
@@ -21,33 +21,33 @@ this.declare_m = function(mname, mode) {
   ASSERT.call(this, false, 'declmode unknown');
 };
 
-this.findDecl = function(name) {
+Scope.prototype.findDecl = function(name) {
   return this.findDecl_m(_m(name));
 };
 
-this.let_m = function(mname, mode) {
+Scope.prototype.let_m = function(mname, mode) {
   return this.declareLexical_m(mname, mode);
 };
 
-this.function_m = function(mname, mode) {
+Scope.prototype.function_m = function(mname, mode) {
   return this.isLexical() ?
     this.declareLexical_m(mname, mode) :
     this.declareVarLike_m(mname, mode);
 };
 
-this.const_m = function(mname, mode) {
+Scope.prototype.const_m = function(mname, mode) {
   return this.declareLexical_m(mname, mode);
 };
 
-this.var_m = function(mname, mode) {
+Scope.prototype.var_m = function(mname, mode) {
   return this.declareVarLike_m(mname, mode);
 };
 
-this.class_m = function(mname, mode) {
+Scope.prototype.class_m = function(mname, mode) {
   return this.declareLexical_m(mname, mode);
 };
 
-this.catchArg_m = function(mname, mode) {
+Scope.prototype.catchArg_m = function(mname, mode) {
   ASSERT.call(this, this.isCatchHead(),
     'only catch heads are allowed to declare catch-args');
 
@@ -64,7 +64,7 @@ this.catchArg_m = function(mname, mode) {
   return newDecl;
 };
 
-this.fnArg_m = function(mname, mode) {
+Scope.prototype.fnArg_m = function(mname, mode) {
   ASSERT.call(this, this.isAnyFnComp() && this.isHead(),
     'only fn heads are allowed to declare fn-args');
 
@@ -97,7 +97,7 @@ this.fnArg_m = function(mname, mode) {
   return newDecl;
 };
 
-this.declareLexical_m = function(mname, mode) {
+Scope.prototype.declareLexical_m = function(mname, mode) {
   var existing = this.findDecl_m(mname);
   if (!existing && this.isAnyFnBody())
     existing = this.funcHead.findDecl_m(mname);
@@ -113,7 +113,7 @@ this.declareLexical_m = function(mname, mode) {
   return newDecl;
 };
 
-this.declareVarLike_m = function(mname, mode) {
+Scope.prototype.declareVarLike_m = function(mname, mode) {
   var dest = null, varDecl = null;
   if (this.isLexical()) {
     var catchScope = this.surroundingCatchScope;
@@ -165,11 +165,11 @@ this.declareVarLike_m = function(mname, mode) {
   return newDecl;
 };
 
-this.findDecl_m = function(mname) {
+Scope.prototype.findDecl_m = function(mname) {
   return this.defs.has(mname) ?
     this.defs.get(mname) : null;
 };
 
-this.insertDecl_m = function(mname, decl) {
+Scope.prototype.insertDecl_m = function(mname, decl) {
   this.defs.set(mname, decl);
 };

--- a/src/decl@Scope.js
+++ b/src/decl@Scope.js
@@ -50,7 +50,7 @@ this.class_m = function(mname, mode) {
 this.catchArg_m = function(mname, mode) {
   ASSERT.call(this, this.isCatchHead(),
     'only catch heads are allowed to declare catch-args');
-  
+
   var existing = this.findDecl_m(mname);
   if (existing)
     this.parser.err('var.catch.is.dup');
@@ -74,7 +74,7 @@ this.fnArg_m = function(mname, mode) {
   var existing = null;
   if (HAS.call(this.paramMap, mname))
     existing = this.paramMap[mname];
-  
+
   if (existing) {
     if (!this.canDup())
       this.parser.err('var.fn.is.dup.arg');
@@ -105,7 +105,7 @@ this.declareLexical_m = function(mname, mode) {
   if (existing)
     this.err('lexical.can.not.override.existing');
 
-  
+
   var newDecl = null, ref = this.findRef_m(mname, true).resolve();
   newDecl = new Decl().m(mode).n(_u(mname)).r(ref);
 

--- a/src/emit-array@Emitter.js
+++ b/src/emit-array@Emitter.js
@@ -28,7 +28,7 @@ this.emitArrayWithSpread = function(list, flags, si) {
   }
   if (startChunk < list.length) {
     if (startChunk > 0) this.wm(',',' ');
-    this.w('[').emitArrayChunk(list, startChunk, list.length-1); 
+    this.w('[').emitArrayChunk(list, startChunk, list.length-1);
     this.w(']');
   }
   this.w(')');

--- a/src/emit-array@Emitter.js
+++ b/src/emit-array@Emitter.js
@@ -9,7 +9,7 @@ Emitters['ArrayExpression'] = function(n, prec, flags) {
   this.w(']');
 };
 
-this.emitArrayWithSpread = function(list, flags, si) {
+Emitter.prototype.emitArrayWithSpread = function(list, flags, si) {
   var paren = flags & EC_NEW_HEAD;
   if (paren) this.w('(');
   this.wm('jz','.','concat','(')
@@ -35,7 +35,7 @@ this.emitArrayWithSpread = function(list, flags, si) {
   if (paren) this.w(')');
 };
 
-this.emitArrayChunk = function(list, from, to) {
+Emitter.prototype.emitArrayChunk = function(list, from, to) {
   var i = from;
   while (i <= to) {
     if (i !== from) this.wm(',',' ');

--- a/src/emit-assig@Emitter.js
+++ b/src/emit-assig@Emitter.js
@@ -1,15 +1,15 @@
 Emitters['SyntheticAssignment'] =
 Emitters['AssignmentExpression'] =
-this.emitAssig = function(n, prec, flags) {
+Emitter.prototype.emitAssig = function(n, prec, flags) {
   this.emitAssigLeft(n.left, flags);
   this.wm(' ',n.operator,' ');
   this.emitAssigRight(n.right);
 };
 
-this.emitAssigLeft = function(n, flags) {
+Emitter.prototype.emitAssigLeft = function(n, flags) {
   return this.emitHead(n, PREC_NONE, flags);
 };
 
-this.emitAssigRight = function(n) {
+Emitter.prototype.emitAssigRight = function(n) {
   this.eN(n, PREC_NONE, EC_NONE);
 };

--- a/src/emit-bexpr@Emitter.js
+++ b/src/emit-bexpr@Emitter.js
@@ -1,6 +1,6 @@
 Emitters['BinaryExpression'] =
 Emitters['LogicalExpression'] =
-this.emitBinary = function(n, prec, flags) {
+Emitter.prototype.emitBinary = function(n, prec, flags) {
   var o = n.operator;
   if (o === '**')
     return this.emitPow(n, flags);
@@ -29,14 +29,14 @@ function isBinaryExpression(n) {
   }
 }
 
-this.emitBinaryExpressionComponent = function(n, flags) {
+Emitter.prototype.emitBinaryExpressionComponent = function(n, flags) {
   if (n.type === 'UnaryExpression' || n.type === 'UpdateExpression')
     return this.emitAny(n, PREC_NONE, flags);
 
   return this.emitHead(n, PREC_NONE, flags);
 };
 
-this.emitRight = function(n, ownerO, flags) {
+Emitter.prototype.emitRight = function(n, ownerO, flags) {
   var childO = n.operator, paren = false;
 
   // previous op has higher prec because it has higher prec
@@ -52,7 +52,7 @@ this.emitRight = function(n, ownerO, flags) {
   if (paren) this.w(')');
 };
 
-this.emitLeft = function(n, childO, flags) {
+Emitter.prototype.emitLeft = function(n, childO, flags) {
   var ownerO = n.operator, paren = false;
 
   if (bp(childO) > bp(ownerO))
@@ -65,7 +65,7 @@ this.emitLeft = function(n, childO, flags) {
   if (paren) this.w(')');
 };
 
-this.emitPow = function(n, flags) {
+Emitter.prototype.emitPow = function(n, flags) {
   var paren = flags & EC_NEW_HEAD;
   if (paren) this.w('(');
   this.wm('jz','.','e','(')

--- a/src/emit-bexpr@Emitter.js
+++ b/src/emit-bexpr@Emitter.js
@@ -32,7 +32,7 @@ function isBinaryExpression(n) {
 this.emitBinaryExpressionComponent = function(n, flags) {
   if (n.type === 'UnaryExpression' || n.type === 'UpdateExpression')
     return this.emitAny(n, PREC_NONE, flags);
-    
+
   return this.emitHead(n, PREC_NONE, flags);
 };
 
@@ -54,7 +54,7 @@ this.emitRight = function(n, ownerO, flags) {
 
 this.emitLeft = function(n, childO, flags) {
   var ownerO = n.operator, paren = false;
-  
+
   if (bp(childO) > bp(ownerO))
     paren = true;
   else if (bp(childO) === bp(ownerO))

--- a/src/emit-block@Emitter.js
+++ b/src/emit-block@Emitter.js
@@ -1,4 +1,4 @@
-this.emitDependentStmt = function(n, isElse) {
+Emitter.prototype.emitDependentStmt = function(n, isElse) {
   if (n.type === 'BlockStatement')
     this.s().emitBlock(n, PREC_NONE, EC_NONE);
   else if (isElse && n.type === 'IfStatement')
@@ -8,7 +8,7 @@ this.emitDependentStmt = function(n, isElse) {
 };
 
 Emitters['BlockStatement'] =
-this.emitBlock = function(n, prec, flags) {
+Emitter.prototype.emitBlock = function(n, prec, flags) {
   this.w('{');
   var list = n.body;
   if (list.length > 0) {

--- a/src/emit-call@Emitter.js
+++ b/src/emit-call@Emitter.js
@@ -21,7 +21,7 @@ Emitters['CallExpression'] = function(n, prec, flags) {
   if (paren) this.w(')');
 };
 
-this.emitCallWithSpread =
+Emitter.prototype.emitCallWithSpread =
 function(n, flags, ri) {
   var paren = flags & EC_NEW_HEAD;
   if (paren) {

--- a/src/emit-call@Emitter.js
+++ b/src/emit-call@Emitter.js
@@ -2,10 +2,10 @@ Emitters['ObjIterGet'] =
 Emitters['Unornull'] =
 Emitters['ArrIterGet'] =
 Emitters['CallExpression'] = function(n, prec, flags) {
-  var ri = spreadIdx(n.arguments, 0); 
+  var ri = spreadIdx(n.arguments, 0);
   if (ri !== -1)
     return this.emitCallWithSpread(n, flags, ri);
-  
+
   var paren = flags & EC_NEW_HEAD;
   if (paren) {
     prec = PREC_NONE;
@@ -37,7 +37,7 @@ function(n, flags, ri) {
         .wm(',',' ');
     if (c.computed)
       this.eN(c.property, PREC_NONE, EC_NONE);
-    else 
+    else
       this.emitStringLiteralWithRawValue("'"+c.property.name+"'");
     this.w(')');
   } else {
@@ -48,5 +48,5 @@ function(n, flags, ri) {
       .emitArrayWithSpread(n.arguments, EC_NONE, ri);
   this.w(')');
   if (paren) this.w(')');
-};  
+};
 

--- a/src/emit-cond@Emitter.js
+++ b/src/emit-cond@Emitter.js
@@ -4,7 +4,7 @@ Emitters['ConditionalExpression'] = function(n, prec, flags) {
   this.wm(' ',':',' ').eN(n.alternate, PREC_NONE, EC_NONE);
 };
 
-this.emitCondTest = function(n, prec, flags) {
+Emitter.prototype.emitCondTest = function(n, prec, flags) {
   var paren = false;
   switch (n.type) {
   case 'AssignmentExpression':

--- a/src/emit-func@Emitter.js
+++ b/src/emit-func@Emitter.js
@@ -17,7 +17,7 @@ Emitters['FunctionDeclaration'] = function(n, prec, flags) {
   if (paren) this.w(')');
 };
 
-this.emitParams = function(list) {
+Emitter.prototype.emitParams = function(list) {
   var i = 0;
   while (i < list.length) {
     if (i) this.wm(',',' ');

--- a/src/emit-id@Emitter.js
+++ b/src/emit-id@Emitter.js
@@ -3,8 +3,8 @@ Emitters['Identifier'] = function(n, prec, flags) {
 };
 
 // TODO: write chunks instead of characters
-this.writeIdentifierName =
-this.emitIdentifierWithValue = function(value) {
+Emitter.prototype.writeIdentifierName =
+Emitter.prototype.emitIdentifierWithValue = function(value) {
   var i = 0;
   while (i < value.length) {
     var ch = value.charCodeAt(i);

--- a/src/emit-if@Emitter.js
+++ b/src/emit-if@Emitter.js
@@ -1,5 +1,5 @@
 Emitters['IfStatement'] =
-this.emitIf = function(n, prec, flags) {
+Emitter.prototype.emitIf = function(n, prec, flags) {
   this
     .wm('if',' ','(')
     .eA(n.test, PREC_NONE, EC_NONE)

--- a/src/emit-literal@Emitter.js
+++ b/src/emit-literal@Emitter.js
@@ -1,5 +1,5 @@
 Emitters['Literal'] =
-this.emitLiteral = function(n, prec, flags) {
+Emitter.prototype.emitLiteral = function(n, prec, flags) {
   switch (n.value) {
   case true: return this.write('true');
   case false: return this.write('false');
@@ -16,12 +16,12 @@ this.emitLiteral = function(n, prec, flags) {
   }
 };
 
-this.emitNumberLiteralWithValue =
+Emitter.prototype.emitNumberLiteralWithValue =
 function(nv) {
   this.write(""+nv);
 };
 
-this.emitStringLiteralWithRawValue =
+Emitter.prototype.emitStringLiteralWithRawValue =
 function(svRaw) {
   this.write(svRaw);
 };

--- a/src/emit-new@Emitter.js
+++ b/src/emit-new@Emitter.js
@@ -4,7 +4,7 @@ Emitters['NewExpression'] = function(n, prec, flags) {
   this.w(')');
 };
 
-this.emitArgList = function(argList) {
+Emitter.prototype.emitArgList = function(argList) {
   var i = 0;
   while (i < argList.length) {
     if (i>0) this.w(',',' ');

--- a/src/emit-obj@Emitter.js
+++ b/src/emit-obj@Emitter.js
@@ -12,7 +12,7 @@ Emitters['ObjectExpression'] = function(n, prec, flags) {
   if (paren) this.w(')');
 };
 
-this.emitObjectChunk = function(list, from, to) {
+Emitter.prototype.emitObjectChunk = function(list, from, to) {
   var i = from;
   while (i <= to) {
     if (i > from) this.wm(',',' ');
@@ -22,7 +22,7 @@ this.emitObjectChunk = function(list, from, to) {
 };
 
 // mi -> member idx
-this.emitObjectWithComputed = function(n, prec, flags, mi) {
+Emitter.prototype.emitObjectWithComputed = function(n, prec, flags, mi) {
   var paren = flags & EC_NEW_HEAD;
   if (paren) this.w('(');
   this.wm('jz','.','obj','(','{');
@@ -44,14 +44,14 @@ this.emitObjectWithComputed = function(n, prec, flags, mi) {
   if (paren) this.w(')');
 };
 
-this.emitProp = function(prop) {
+Emitter.prototype.emitProp = function(prop) {
   ASSERT.call(this, !prop.computed,
     'computed prop is not emittable by this function');
   this.emitNonComputed(prop.key);
   this.wm(':',' ').eN(prop.value);
 };
 
-this.emitNonComputed = function(name) {
+Emitter.prototype.emitNonComputed = function(name) {
   switch (name.type) {
   case 'Identifier':
     if (this.isReserved(name.name))
@@ -70,7 +70,7 @@ this.emitNonComputed = function(name) {
   }
 };
 
-this.emitNonComputedAsString = function(name) {
+Emitter.prototype.emitNonComputedAsString = function(name) {
   switch (name.type) {
   case 'Identifier':
     return this.emitStringLiteralWithRawValue("'"+name.name+"'");

--- a/src/emit-obj@Emitter.js
+++ b/src/emit-obj@Emitter.js
@@ -7,7 +7,7 @@ Emitters['ObjectExpression'] = function(n, prec, flags) {
   var paren = flags & EC_START_STMT;
 
   if (paren) this.w('(');
-  this.w('{').emitObjectChunk(list, 0, list.length-1); 
+  this.w('{').emitObjectChunk(list, 0, list.length-1);
   this.w('}')
   if (paren) this.w(')');
 };
@@ -35,17 +35,17 @@ this.emitObjectWithComputed = function(n, prec, flags, mi) {
     this.wm(',',' ');
     if (prop.computed) this.eN(prop.key);
     else this.emitNonComputedAsString(prop.key);
-    
+
     this.wm(',',' ').eN(prop.value);
-    
+
     ++mi;
   }
   this.w(')');
   if (paren) this.w(')');
-};  
+};
 
 this.emitProp = function(prop) {
-  ASSERT.call(this, !prop.computed, 
+  ASSERT.call(this, !prop.computed,
     'computed prop is not emittable by this function');
   this.emitNonComputed(prop.key);
   this.wm(':',' ').eN(prop.value);
@@ -59,7 +59,7 @@ this.emitNonComputed = function(name) {
     else
       this.emitIdentifierWithValue(name.name);
     break;
-  
+
   case 'Literal':
     this.emitLiteral(name);
     break;

--- a/src/emit-switch@Emitter.js
+++ b/src/emit-switch@Emitter.js
@@ -11,7 +11,7 @@ Emitters['SwitchStatement'] = function(n, prec, flags) {
   this.w('}');
 };
 
-this.emitCase = function(c) {
+Emitter.prototype.emitCase = function(c) {
   if (c.test) {
     this.wm('case',' ')
         .eA(c.test, PREC_NONE, EC_NONE)

--- a/src/emit-synth-seq@Emitter.js
+++ b/src/emit-synth-seq@Emitter.js
@@ -6,7 +6,7 @@ Emitters['SequenceStatement'] = function(n, prec, flags) {
   }
 };
 
-this.emitAsStmt = function(seqElem) {
+Emitter.prototype.emitAsStmt = function(seqElem) {
   switch (seqElem.type) {
   case 'AssignmentExpression':
   case 'SyntheticAssignment':

--- a/src/emit-try@Emitter.js
+++ b/src/emit-try@Emitter.js
@@ -6,7 +6,7 @@ Emitters['TryStatement'] = function(n, prec, flags) {
     this.l().w('finally').emitDependentStmt(n.finalizer);
 };
 
-this.emitCatchClause = function(c) {
+Emitter.prototype.emitCatchClause = function(c) {
   this.wm('catch',' ','(').emitIdentifierWithValue('err');
   this.w(')').emitDependentStmt(c.body);
 };

--- a/src/emit-unary@Emitter.js
+++ b/src/emit-unary@Emitter.js
@@ -9,7 +9,7 @@ Emitters['UnaryExpression'] = function(n, prec, flags) {
   this.emitUnaryArgument(n.argument);
 };
 
-this.emitUnaryArgument = function(n) {
+Emitter.prototype.emitUnaryArgument = function(n) {
   if (n.type === 'UnaryExpression' || n.type === 'UpdateExpression')
     this.emitAny(n, PREC_NONE, EC_NONE);
   else

--- a/src/err-listener@Parser.js
+++ b/src/err-listener@Parser.js
@@ -7,7 +7,7 @@ this.onErr = function(errorType, errParams) {
        this.src.substr(this.c, 120);
 
    else {
-     var errorBuilder = ErrorBuilders[errorType];  
+     var errorBuilder = ErrorBuilders[errorType];
      var errorInfo = this.buildErrorInfo(errorBuilder, errParams);
 
      var offset = errorInfo.c0,
@@ -23,7 +23,7 @@ this.onErr = function(errorType, errParams) {
 
    throw new Error(message);
 };
-  
+
 // TODO: find a way to squash it with normalize
 this.buildErrorInfo = function(builder, params) {
   if (builder.preprocessor !== null)
@@ -100,7 +100,7 @@ function a(errorType, builderOutline) {
     if (name === 'm')
       builder.messageTemplate = ErrorString.from(builderOutline[name]);
     else if (name === 'p')
-      builder.preprocessor = builderOutline.p; 
+      builder.preprocessor = builderOutline.p;
     else
       builder[name] = Template.from(builderOutline[name]);
   }
@@ -116,7 +116,7 @@ function set(newErrorType, existingErrorType) {
       newErrorType+'> with <'+existingErrorType);
   if (!HAS.call(ErrorBuilders, existingErrorType))
     throw new Error('error is not defined: <'+existingErrorType+'>');
-  
+
   var builder = ErrorBuilders[existingErrorType];
   ErrorBuilders[newErrorType] = builder;
 
@@ -352,7 +352,7 @@ set('incdec.pre.not.simple.assig', 'incdec.post.not.simple.assig');
 a('label.is.a.dup', {m:'{tn.name} has been actually declared at {extra.li0}:{extra:col0} (offset {extra.c0})'}, 'a: a: for (;false;) break;');
 
 // TODO:
-// a('let.dcl.not.in.block',{m: 
+// a('let.dcl.not.in.block',{m:
 
 a('lexical.decl.not.in.block',{m:'a {extra.kind}-binding can not be declared in this scope'}, 'if (false) const a = 12;');
 
@@ -387,7 +387,7 @@ a('nexpr.null.head',{m:'unexpected {parser.lttype} -- something that can start a
 a('non.tail.rest',{m:'a rest element can not be followed by a comma (a fact that also implies it must be the very last element)'}, '[...a,]=12');
 
 // TODO: this.noSemiAfter(nodeType)
-a('no.semi',{m:'a semicolon was expected (or a \'}\' if appropriate), but got a {parser.lttype}'},'a e'); 
+a('no.semi',{m:'a semicolon was expected (or a \'}\' if appropriate), but got a {parser.lttype}'},'a e');
 
 a('not.assignable',{m:'{tn.type} is not a valid assignment left hand side'},'a[0]-- = 12');
 

--- a/src/err-listener@Parser.js
+++ b/src/err-listener@Parser.js
@@ -1,4 +1,4 @@
-this.onErr = function(errorType, errParams) {
+Parser.prototype.onErr = function(errorType, errParams) {
    var message = "";
    if (!HAS.call(ErrorBuilders, errorType))
      message = "Error: " + errorType + "\n" +
@@ -25,7 +25,7 @@ this.onErr = function(errorType, errParams) {
 };
 
 // TODO: find a way to squash it with normalize
-this.buildErrorInfo = function(builder, params) {
+Parser.prototype.buildErrorInfo = function(builder, params) {
   if (builder.preprocessor !== null)
     builder.preprocessor.call(params);
 

--- a/src/err-tricky@Parser.js
+++ b/src/err-tricky@Parser.js
@@ -1,12 +1,12 @@
-this.currentExprIsParams = function() {
+Parser.prototype.currentExprIsParams = function() {
   this.st = this.pt = this.at = this.st = ERR_NONE_YET;
 };
 
-this.currentExprIsAssig = function() {
+Parser.prototype.currentExprIsAssig = function() {
   this.st = this.pt = this.at = ERR_NONE_YET;
 };
 
-this.currentExprIsSimple = function() {
+Parser.prototype.currentExprIsSimple = function() {
   this.pt = this.at = ERR_NONE_YET;
   if (this.st !== ERR_NONE_YET) {
     var st = this.st;
@@ -31,7 +31,7 @@ tm[ERR_ASYNC_NEWLINE_BEFORE_PAREN] = 'async.newline.before.paren';
 tm[ERR_PIN_NOT_AN_EQ] = 'complex.assig.not.pattern';
 
 // TODO: trickyContainer
-this.throwTricky = function(source, trickyType) {
+Parser.prototype.throwTricky = function(source, trickyType) {
   if (!HAS.call(tm, trickyType))
     throw new Error("Unknown error value: "+trickyType);
 
@@ -51,7 +51,7 @@ this.throwTricky = function(source, trickyType) {
   this.err(tm[trickyType], errParams);
 };
 
-this.adjustErrors = function() {
+Parser.prototype.adjustErrors = function() {
   if (this.st === ERR_ARGUMENTS_OR_EVAL_ASSIGNED)
     this.st = ERR_ARGUMENTS_OR_EVAL_DEFAULT;
   else

--- a/src/err-tricky@Parser.js
+++ b/src/err-tricky@Parser.js
@@ -49,9 +49,9 @@ this.throwTricky = function(source, trickyType) {
   }
   errParams.extra = { source: source };
   this.err(tm[trickyType], errParams);
-}; 
+};
 
-this.adjustErrors = function() { 
+this.adjustErrors = function() {
   if (this.st === ERR_ARGUMENTS_OR_EVAL_ASSIGNED)
     this.st = ERR_ARGUMENTS_OR_EVAL_DEFAULT;
   else

--- a/src/err@Parser.js
+++ b/src/err@Parser.js
@@ -1,9 +1,9 @@
-this.err = function(errorType, errParams) {
+Parser.prototype.err = function(errorType, errParams) {
   errParams = this.normalize(errParams);
   return this.errorListener.onErr(errorType, errParams);
 };
 
-this.normalize = function(err) {
+Parser.prototype.normalize = function(err) {
   // normalized err
   var loc0 = { li: this.li0, col: this.col0 },
       loc = { li: this.li, col: this.col };

--- a/src/err@Parser.js
+++ b/src/err@Parser.js
@@ -15,7 +15,7 @@ this.normalize = function(err) {
     parser: this,
     extra: null
   };
-  
+
   if (err) {
     if (err.tn) {
       var tn = err.tn;
@@ -47,11 +47,11 @@ this.normalize = function(err) {
 
     if (HAS.call(err,'c0'))
       e.cur0.c = err.c0;
-    
+
     if (HAS.call(err,'c'))
       e.cur.c = err.c;
 
-    if (HAS.call(err, 'extra')) 
+    if (HAS.call(err, 'extra'))
       e.extra = err.extra;
   }
 

--- a/src/error-constants.js
+++ b/src/error-constants.js
@@ -48,7 +48,7 @@ var ERR_NONE_YET = 0,
     ERR_ASYNC_NEWLINE_BEFORE_PAREN = newErr(ERR_P_SYN),
 
     ERR_ARGUMENTS_OR_EVAL_DEFAULT = newErr(ERR_S_SYN),
- 
+
     // function l() { '\12'; 'use strict'; }
     ERR_PIN_OCTAL_IN_STRICT = newErr(ERR_S_SYN|ERR_PIN),
 

--- a/src/finish@Scope.js
+++ b/src/finish@Scope.js
@@ -1,9 +1,9 @@
-this.finish = function() {
+Scope.prototype.finish = function() {
   this.tailI = this.iRef.v-1;
   this.handOverRefsToParent();
 };
 
-this.handOverRefsToParent = function() {
+Scope.prototype.handOverRefsToParent = function() {
   var list = this.refs.keys, i = 0;
   while (i < list.length) {
     var ref = this.refs.at(i);

--- a/src/init@Parser.js
+++ b/src/init@Parser.js
@@ -9,7 +9,7 @@ function get(obj, name, value) {
     case NUMBER_TYPE:
     case BOOL_TYPE:
     case STRING_TYPE:
-      if (typeof obj[name] !== t) 
+      if (typeof obj[name] !== t)
         return value;
     default:
       return obj[name];
@@ -58,7 +58,7 @@ this.setOptions = function(o) {
       break;
 
     case 'sourceFile':
-      this.misc.sourceFile = 
+      this.misc.sourceFile =
         get(o, cur, "");
       break;
 

--- a/src/init@Parser.js
+++ b/src/init@Parser.js
@@ -16,7 +16,7 @@ function get(obj, name, value) {
   }
 }
 
-this.setOptions = function(o) {
+Parser.prototype.setOptions = function(o) {
   var list = OPTIONS, e = 0;
   while (e < list.length) {
     var cur = list[e++];

--- a/src/loc@Parser.js
+++ b/src/loc@Parser.js
@@ -1,5 +1,5 @@
-this.loc = function() { return { line: this.li, column: this.col }; };
-this.locBegin = function() { return  { line: this.li0, column: this.col0 }; };
-this.locOn = function(l) { return { line: this.li, column: this.col - l }; };
+Parser.prototype.loc = function() { return { line: this.li, column: this.col }; };
+Parser.prototype.locBegin = function() { return  { line: this.li0, column: this.col0 }; };
+Parser.prototype.locOn = function(l) { return { line: this.li, column: this.col - l }; };
 
 

--- a/src/mexport.js
+++ b/src/mexport.js
@@ -3,7 +3,7 @@ this.parse = function(src, isModule ) {
   return newp.parseProgram();
 };
 
-this.Parser = Parser;  
+this.Parser = Parser;
 this.ErrorString = ErrorString;
 this.Template = Template;
 this.Emitter = Emitter;

--- a/src/next@Parser.js
+++ b/src/next@Parser.js
@@ -1,4 +1,4 @@
-this.next = function () {
+Parser.prototype.next = function () {
   if (this.onToken_ !== null) {
     switch (this.lttype) {
     case "eof":
@@ -220,7 +220,7 @@ this.next = function () {
   this.col += ( this.c - start );
 };
 
-this . opEq = function()  {
+Parser.prototype. opEq = function()  {
     var c = this.c;
     var l = this.src;
     this.lttype = 'op';
@@ -247,7 +247,7 @@ this . opEq = function()  {
     this.c=c;
 };
 
-this . opMin = function() {
+Parser.prototype. opMin = function() {
    var c = this.c;
    var l = this.src;
    c++;
@@ -273,7 +273,7 @@ this . opMin = function() {
    this.c=c;
 };
 
-this . opLess = function () {
+Parser.prototype. opLess = function () {
   var c = this.c;
   var l = this.src;
   this.lttype = 'op';
@@ -303,7 +303,7 @@ this . opLess = function () {
   this.c=c;
 };
 
-this . opAdd = function() {
+Parser.prototype. opAdd = function() {
    var c = this.c;
    var l = this.src;
    c++ ;
@@ -329,7 +329,7 @@ this . opAdd = function() {
    this.c=c;
 };
 
-this . opGrea = function()   {
+Parser.prototype. opGrea = function()   {
   var c = this.c;
   var l = this.src;
   this.lttype = 'op';
@@ -370,7 +370,7 @@ this . opGrea = function()   {
   this.c=c;
 };
 
-this.skipS = function() {
+Parser.prototype.skipS = function() {
   var noNewLine = true,
       startOffset = this.c,
       c = this.c,
@@ -483,7 +483,7 @@ this.skipS = function() {
   this.nl = !noNewLine ;
 };
 
-this.readDot = function() {
+Parser.prototype.readDot = function() {
    ++this.c;
    if( this.src.charCodeAt(this.c)===CH_SINGLEDOT) {
      if (this.src.charCodeAt(++ this.c) === CH_SINGLEDOT) { this.lttype = '...' ;   ++this.c; return ; }
@@ -501,9 +501,9 @@ this.readDot = function() {
    this. ltraw = this.lttype = '.' ;
 };
 
-this.readMisc = function () { this.lttype = this.  src.   charAt (   this.c ++  )    ; };
+Parser.prototype.readMisc = function () { this.lttype = this.  src.   charAt (   this.c ++  )    ; };
 
-this.expectID = function (n) {
+Parser.prototype.expectID = function (n) {
   if (this.lttype === 'Identifier' && this.ltval === n)
     return this.next();
 
@@ -513,7 +513,7 @@ this.expectID = function (n) {
   this.err('unexpected.id',{extra:n});
 };
 
-this.expectType_soft = function (n)  {
+Parser.prototype.expectType_soft = function (n)  {
   if (this.lttype === n ) {
       this.next();
       return true;
@@ -522,7 +522,7 @@ this.expectType_soft = function (n)  {
   return false;
 };
 
-this.expectID_soft = function (n) {
+Parser.prototype.expectID_soft = function (n) {
   if (this.lttype === 'Identifier' && this.ltval === n) {
      this.next();
      return true;
@@ -531,7 +531,7 @@ this.expectID_soft = function (n) {
   return false;
 };
 
-this.kw = function() {
+Parser.prototype.kw = function() {
   if (this.onToken_)
     this.lttype = 'Keyword';
 };

--- a/src/next@Parser.js
+++ b/src/next@Parser.js
@@ -185,7 +185,7 @@ this.next = function () {
           peek = l.charCodeAt(++ this.c);
           if (peek !== CH_u )
               return this.err('id.u.not.after.slash');
-          
+
           else
              peek = this.peekUSeq();
 
@@ -203,13 +203,13 @@ this.next = function () {
             if ( mustBeAnID === 1 ) return this.err('id.esc.must.be.idhead',{extra:peek});
             else return this.err('id.multi.must.be.idhead',{extra:[peek,r]});
           }
- 
+
           this.readAnIdentifierToken( mustBeAnID === 2 ?
               String.fromCharCode( peek, r ) :
               fromcode( peek )
           );
         }
-        else 
+        else
           this.readMisc();
     }
 
@@ -393,7 +393,7 @@ this.skipS = function() {
 
     case CH_VTAB:
     case CH_TAB:
-    case CH_FORM_FEED: c++ ; continue ;  
+    case CH_FORM_FEED: c++ ; continue ;
 
     case CH_DIV:
       switch ( l.charCodeAt ( c + ( 1) ) ) {
@@ -458,7 +458,7 @@ this.skipS = function() {
       this.c=c;
       this.nl = !noNewLine ;
       return ;
- 
+
     case CH_MIN:
       if (this.v > 5 && (!noNewLine || startOffset === 0) &&
            this.isScript &&
@@ -469,7 +469,7 @@ this.skipS = function() {
         c = this.c;
         continue;
       }
-  
+
     default :
       this.col += (c-start ) ;
       this.c=c;
@@ -506,10 +506,10 @@ this.readMisc = function () { this.lttype = this.  src.   charAt (   this.c ++  
 this.expectID = function (n) {
   if (this.lttype === 'Identifier' && this.ltval === n)
     return this.next();
-  
+
   if (this.lttype !== 'Identifier')
     this.err('an.id.was.expected',{extra:n});
- 
+
   this.err('unexpected.id',{extra:n});
 };
 

--- a/src/parse-aamm@Parser.js
+++ b/src/parse-aamm@Parser.js
@@ -1,4 +1,4 @@
-this.parseUpdateExpression = function(arg, context) {
+Parser.prototype.parseUpdateExpression = function(arg, context) {
   var c = 0, loc = null, u = this.ltraw;
   if (arg === null) {
     c = this.c-2;

--- a/src/parse-arglist@Parser.js
+++ b/src/parse-arglist@Parser.js
@@ -2,9 +2,9 @@ this.parseArgList = function () {
   var c0 = -1, li0 = -1, col0 = -1, parenAsync = this.parenAsync,
       elem = null, list = [];
 
-  do { 
+  do {
     this.next();
-    elem = this.parseNonSeqExpr(PREC_WITH_NO_OP,CTX_NULLABLE|CTX_PAT|CTX_NO_SIMPLE_ERR); 
+    elem = this.parseNonSeqExpr(PREC_WITH_NO_OP,CTX_NULLABLE|CTX_PAT|CTX_NO_SIMPLE_ERR);
     if (elem)
       list.push(core(elem));
     else if (this.lttype === '...')

--- a/src/parse-arglist@Parser.js
+++ b/src/parse-arglist@Parser.js
@@ -1,4 +1,4 @@
-this.parseArgList = function () {
+Parser.prototype.parseArgList = function () {
   var c0 = -1, li0 = -1, col0 = -1, parenAsync = this.parenAsync,
       elem = null, list = [];
 

--- a/src/parse-array@Parser.js
+++ b/src/parse-array@Parser.js
@@ -1,4 +1,4 @@
-this.parseArrayExpression = function(context) {
+Parser.prototype.parseArrayExpression = function(context) {
 
   var startc = this.c - 1,
       startLoc = this.locOn(1);

--- a/src/parse-array@Parser.js
+++ b/src/parse-array@Parser.js
@@ -51,7 +51,7 @@ this.parseArrayExpression = function(context) {
     }
     if (this.lttype === ',') {
       if (hasRest)
-        hasNonTailRest = true; 
+        hasNonTailRest = true;
       if (elem === null) {
         if (this.v <= 5) this.err('ver.elision');
         list.push(null);
@@ -66,7 +66,7 @@ this.parseArrayExpression = function(context) {
       }
       else break;
     }
- 
+
     if (elemContext & CTX_PARAM)
       elem && this.scope.addPossibleArgument(elem);
 
@@ -79,7 +79,7 @@ this.parseArrayExpression = function(context) {
       else if (hasNonTailRest)
         t = ERR_NON_TAIL_REST;
 
-      if ((elemContext & CTX_PARAM) && 
+      if ((elemContext & CTX_PARAM) &&
          !(elemContext & CTX_HAS_A_PARAM_ERR)) {
         if (this.pt === ERR_NONE_YET && t !== ERR_NONE_YET) {
           this.pt = t; this.pe = elemCore;
@@ -89,7 +89,7 @@ this.parseArrayExpression = function(context) {
             pt = this.pt; pe = this.pe; po = core(elem);
             if (pt & ERR_P_SYN)
               elemContext |= CTX_HAS_A_PARAM_ERR;
-            if (pt & ERR_PIN) 
+            if (pt & ERR_PIN)
               pc0 = this.ploc.c0, pli0 = this.ploc.li0, pcol0 = this.ploc.col0;
           }
         }
@@ -129,7 +129,7 @@ this.parseArrayExpression = function(context) {
 
     hasRest = hasNonTailRest = false;
   }
-  
+
   var n = {
     type: 'ArrayExpression',
     loc: { start: startLoc, end: this.loc() },
@@ -156,6 +156,6 @@ this.parseArrayExpression = function(context) {
 
   if (!this.expectType_soft(']'))
     this.err('array.unfinished');
-  
+
   return n;
 };

--- a/src/parse-arrow@Parser.js
+++ b/src/parse-arrow@Parser.js
@@ -102,7 +102,7 @@ this.parseArrowFunctionExpression = function(arg, context)   {
   }
 
   return {
-    type: 'ArrowFunctionExpression', params: params, 
+    type: 'ArrowFunctionExpression', params: params,
     start: arg.start, end: nbody.end,
     loc: {
       start: arg.loc.start,
@@ -111,6 +111,6 @@ this.parseArrowFunctionExpression = function(arg, context)   {
     generator: false, expression: isExpr,
     body: core(nbody), id : null,
     async: async
-  }; 
+  };
 };
 

--- a/src/parse-arrow@Parser.js
+++ b/src/parse-arrow@Parser.js
@@ -1,4 +1,4 @@
-this.parseArrowFunctionExpression = function(arg, context)   {
+Parser.prototype.parseArrowFunctionExpression = function(arg, context)   {
   if (this.v <= 5)
     this.err('ver.arrow');
   var tight = this.scope.insideStrict(), async = false;

--- a/src/parse-assig@Parser.js
+++ b/src/parse-assig@Parser.js
@@ -83,7 +83,7 @@ this.parseAssignment = function(head, context) {
       this.at = ERR_PIN_NOT_AN_EQ;
     }
   }
- 
+
   return {
     type: 'AssignmentExpression',
     operator: o,

--- a/src/parse-assig@Parser.js
+++ b/src/parse-assig@Parser.js
@@ -1,4 +1,4 @@
-this.parseAssignment = function(head, context) {
+Parser.prototype.parseAssignment = function(head, context) {
   var o = this.ltraw;
   if (o === '=>')
     return this.parseArrowFunctionExpression(head);

--- a/src/parse-async@Parser.js
+++ b/src/parse-async@Parser.js
@@ -3,14 +3,14 @@ function idAsync(c0,li0,col0,raw) {
     type: 'Identifier', name: 'async',
     start: c0, end: c0 + raw.length,
     loc: {
-      start: { line: li0, column: col0 }, 
+      start: { line: li0, column: col0 },
       end: { line: li0, column: col0 + raw.length }
     }, raw: raw
   };
 }
 
 this.parseAsync = function(context) {
-  if (this.v < 7) 
+  if (this.v < 7)
     return this.id();
 
   var c0 = this.c0,
@@ -65,7 +65,7 @@ this.parseAsync = function(context) {
   case '(':
     if (context & CTX_ASYNC_NO_NEWLINE_FN) {
       n = null;
-      break; 
+      break;
     }
     var hasNewLineBeforeParen = this.nl;
     var args = this.parseParen(context & CTX_PAT), async = idAsync(c0,li0,col0,raw);
@@ -81,7 +81,7 @@ this.parseAsync = function(context) {
           [args.expr] :
         []
     };
-    
+
     if ((context & CTX_PAT) && hasNewLineBeforeParen) {
       this.pt = ERR_ASYNC_NEWLINE_BEFORE_PAREN;
       this.pe = n;
@@ -109,7 +109,7 @@ this.parseAsync_intermediate = function(c0, li0, col0) {
     type: INTERMEDIATE_ASYNC,
     id: id,
     start: c0,
-    loc: { 
+    loc: {
       start: { line: li0, column: col0 }
     }
   };

--- a/src/parse-async@Parser.js
+++ b/src/parse-async@Parser.js
@@ -9,7 +9,7 @@ function idAsync(c0,li0,col0,raw) {
   };
 }
 
-this.parseAsync = function(context) {
+Parser.prototype.parseAsync = function(context) {
   if (this.v < 7)
     return this.id();
 
@@ -103,7 +103,7 @@ this.parseAsync = function(context) {
   return n;
 };
 
-this.parseAsync_intermediate = function(c0, li0, col0) {
+Parser.prototype.parseAsync_intermediate = function(c0, li0, col0) {
   var id = this.validateID("");
   return {
     type: INTERMEDIATE_ASYNC,

--- a/src/parse-block@Parser.js
+++ b/src/parse-block@Parser.js
@@ -1,4 +1,4 @@
-this.parseBlockStatement = function () {
+Parser.prototype.parseBlockStatement = function () {
   this.fixupLabels(false);
 
   this.enterScope(this.scope.blockScope());

--- a/src/parse-block@Parser.js
+++ b/src/parse-block@Parser.js
@@ -1,7 +1,7 @@
 this.parseBlockStatement = function () {
   this.fixupLabels(false);
 
-  this.enterScope(this.scope.blockScope()); 
+  this.enterScope(this.scope.blockScope());
 
   var startc = this.c - 1,
       startLoc = this.locOn(1);
@@ -14,7 +14,7 @@ this.parseBlockStatement = function () {
         this.err('block.unfinished',{tn:n,extra:{delim:'}'}}))
     return this.errorHandlerOutput ;
 
-  this.exitScope(); 
+  this.exitScope();
 
   return n;
 };

--- a/src/parse-break@Parser.js
+++ b/src/parse-break@Parser.js
@@ -1,4 +1,4 @@
-this.parseBreakStatement = function () {
+Parser.prototype.parseBreakStatement = function () {
    if (!this.ensureStmt_soft())
      this.err('not.stmt');
 

--- a/src/parse-catch@Parser.js
+++ b/src/parse-catch@Parser.js
@@ -1,4 +1,4 @@
-this. parseCatchClause = function () {
+Parser.prototype. parseCatchClause = function () {
    var startc = this.c0,
        startLoc = this.locBegin();
 

--- a/src/parse-class@Parser.js
+++ b/src/parse-class@Parser.js
@@ -80,7 +80,7 @@ this. parseClass = function(context) {
       type: 'ClassBody', loc: { start: startLocBody, end: endLoc },
       start: startcBody, end: this.c,
       body: list/* ,y:-1*/
-    }/* ,y:-1*/ 
+    }/* ,y:-1*/
   };
 
   if (!this.expectType_soft('}'))
@@ -101,26 +101,26 @@ this.parseSuper = function() {
     type: 'Super', loc: { start: this.locBegin(), end: this.loc() },
     start: this.c0, end: this.c
   };
- 
+
   this.next();
   switch ( this.lttype ) {
   case '(':
     if (!this.scope.canSupCall())
       this.err('class.super.call',{tn:n});
- 
+
     break;
- 
+
   case '.':
   case '[':
     if (!this.scope.canSupMem())
       this.err('class.super.mem',{tn:n});
- 
+
     break ;
-  
+
   default:
-    this.err('class.super.lone',{tn:n}); 
+    this.err('class.super.lone',{tn:n});
 
   }
- 
+
   return n;
 };

--- a/src/parse-class@Parser.js
+++ b/src/parse-class@Parser.js
@@ -1,4 +1,4 @@
-this. parseClass = function(context) {
+Parser.prototype. parseClass = function(context) {
   if (this.v <= 5)
     this.err('ver.class');
   if (this.unsatisfiedLabel)
@@ -94,7 +94,7 @@ this. parseClass = function(context) {
   return n;
 };
 
-this.parseSuper = function() {
+Parser.prototype.parseSuper = function() {
   if (this.v <=5 ) this.err('ver.super');
 
   var n = {

--- a/src/parse-comment@Parser.js
+++ b/src/parse-comment@Parser.js
@@ -1,4 +1,4 @@
-this.readMultiComment = function () {
+Parser.prototype.readMultiComment = function () {
   var c = this.c, l = this.src, e = l.length,
       r = -1, n = true, start = c;
 
@@ -43,7 +43,7 @@ this.readMultiComment = function () {
   this.err( 'comment.multi.unfinished',{extra:{c0:c0,li0:li0,col0:col0}});
 };
 
-this.readLineComment = function() {
+Parser.prototype.readLineComment = function() {
   var c = this.c, l = this.src,
       e = l.length, r = -1;
 

--- a/src/parse-comment@Parser.js
+++ b/src/parse-comment@Parser.js
@@ -63,7 +63,7 @@ this.readLineComment = function() {
       this.col = 0 ;
       this.li++;
       break L;
-    
+
 //  default : if ( r >= 0x0D800 && r <= 0x0DBFF ) this.col-- ;
     }
 

--- a/src/parse-cond@Parser.js
+++ b/src/parse-cond@Parser.js
@@ -1,4 +1,4 @@
-this.parseCond = function(cond, context) {
+Parser.prototype.parseCond = function(cond, context) {
   this.next();
   var seq =
     this.parseNonSeqExpr(PREC_WITH_NO_OP, CTX_NONE);

--- a/src/parse-continue@Parser.js
+++ b/src/parse-continue@Parser.js
@@ -1,4 +1,4 @@
-this.parseContinueStatement = function () {
+Parser.prototype.parseContinueStatement = function () {
    if (!this.ensureStmt_soft())
      this.err('not.stmt');
 

--- a/src/parse-debugger@Parser.js
+++ b/src/parse-debugger@Parser.js
@@ -1,4 +1,4 @@
-this . prseDbg = function () {
+Parser.prototype. prseDbg = function () {
   if (! this.ensureStmt_soft () &&
         this.err('not.stmt') )
     return this.errorHandlerOutput ;

--- a/src/parse-debugger@Parser.js
+++ b/src/parse-debugger@Parser.js
@@ -15,7 +15,7 @@ this . prseDbg = function () {
     li = this.li;
     col = this.col;
     this.next();
-  } 
+  }
   else if ( !this.nl &&
      this.err('no.semi') )
      return this.errorHandlerOutput;

--- a/src/parse-dependent-block@Parser.js
+++ b/src/parse-dependent-block@Parser.js
@@ -1,4 +1,4 @@
-this. parseBlockStatement_dependent = function(name) {
+Parser.prototype. parseBlockStatement_dependent = function(name) {
     var startc = this.c - 1,
         startLoc = this.locOn(1);
 

--- a/src/parse-do@Parser.js
+++ b/src/parse-do@Parser.js
@@ -34,7 +34,7 @@ this.parseDoWhileStatement = function () {
   }
 
  this.foundStatement = true;
- this.exitScope(); 
+ this.exitScope();
 
  return { type: 'DoWhileStatement', test: cond, start: startc, end: c,
           body: nbody, loc: { start: startLoc, end: { line: li, column: col } } /* ,y:-1*/} ;

--- a/src/parse-do@Parser.js
+++ b/src/parse-do@Parser.js
@@ -1,4 +1,4 @@
-this.parseDoWhileStatement = function () {
+Parser.prototype.parseDoWhileStatement = function () {
   if (!this.ensureStmt_soft())
     this.err('not.stmt');
 

--- a/src/parse-empty@Parser.js
+++ b/src/parse-empty@Parser.js
@@ -1,4 +1,4 @@
-this .parseEmptyStatement = function() {
+Parser.prototype.parseEmptyStatement = function() {
   var n = { type: 'EmptyStatement',
            start: this.c - 1,
            loc: { start: this.locOn(1), end: this.loc() },

--- a/src/parse-esc-general@Parser.js
+++ b/src/parse-esc-general@Parser.js
@@ -79,15 +79,15 @@ this.readEsc = function ()  {
        b  = b0 - CH_0;
        b0 = src.charCodeAt(this.c + 1 );
        if ( b0 >= CH_0 && b0 < CH_8 ) {
-          this.c++; 
-          b <<= 3; 
+          this.c++;
+          b <<= 3;
           b += (b0-CH_0);
        }
        return String.fromCharCode(b)  ;
 
    case CH_8:
    case CH_9:
-       if ( this.err('esc.8.or.9') ) 
+       if ( this.err('esc.8.or.9') )
          return this.errorHandlerOutput ;
        return '';
 
@@ -152,7 +152,7 @@ this.readStrictEsc = function ()  {
 
    case CH_8:
    case CH_9:
-       if ( this.err('esc.8.or.9') ) 
+       if ( this.err('esc.8.or.9') )
          return this.errorHandlerOutput ;
 
    case CH_CARRIAGE_RETURN:

--- a/src/parse-esc-general@Parser.js
+++ b/src/parse-esc-general@Parser.js
@@ -1,4 +1,4 @@
-this.readEsc = function ()  {
+Parser.prototype.readEsc = function ()  {
   var src = this.src, b0 = 0, b = 0, start = this.c;
   switch ( src.charCodeAt ( ++this.c ) ) {
    case CH_BACK_SLASH: return '\\';
@@ -106,7 +106,7 @@ this.readEsc = function ()  {
   }
 };
 
-this.readStrictEsc = function ()  {
+Parser.prototype.readStrictEsc = function ()  {
   var src = this.src, b0 = 0, b = 0;
   switch ( src.charCodeAt ( ++this.c ) ) {
    case CH_BACK_SLASH: return '\\';

--- a/src/parse-esc-unicode@Parser.js
+++ b/src/parse-esc-unicode@Parser.js
@@ -19,7 +19,7 @@ this.peekUSeq = function () {
   var c = ++this.c, l = this.src, e = l.length;
   var byteVal = 0;
   var n = l.charCodeAt(c);
-  if (CH_LCURLY === n) { // u{ 
+  if (CH_LCURLY === n) { // u{
     ++c;
     n = l.charCodeAt(c);
     do {
@@ -35,13 +35,13 @@ this.peekUSeq = function () {
       n = l.charCodeAt( ++ c);
     } while (c < e && n !== CH_RCURLY);
 
-    if ( n !== CH_RCURLY && this.err('u.curly.is.unfinished',{c0:c}) ) 
+    if ( n !== CH_RCURLY && this.err('u.curly.is.unfinished',{c0:c}) )
       return this.errorHandlerOutput ;
 
     this.c = c;
     return byteVal;
   }
- 
+
   n = toNum(l.charCodeAt(c));
   if ( n === -1 && this.err('u.esc.hex',{c0:c}) )
     return this.errorHandlerOutput;

--- a/src/parse-esc-unicode@Parser.js
+++ b/src/parse-esc-unicode@Parser.js
@@ -1,5 +1,5 @@
 
-this.peekTheSecondByte = function () {
+Parser.prototype.peekTheSecondByte = function () {
   var e = this.src.charCodeAt(this.c), start = this.c;
   if (CH_BACK_SLASH === e) {
     if (CH_u !== this.src.charCodeAt(++this.c) &&
@@ -15,7 +15,7 @@ this.peekTheSecondByte = function () {
   return e;
 };
 
-this.peekUSeq = function () {
+Parser.prototype.peekUSeq = function () {
   var c = ++this.c, l = this.src, e = l.length;
   var byteVal = 0;
   var n = l.charCodeAt(c);

--- a/src/parse-export@Parser.js
+++ b/src/parse-export@Parser.js
@@ -1,4 +1,4 @@
-this.parseExport = function() {
+Parser.prototype.parseExport = function() {
   if (this.v <= 5) this.err('ver.exim');
 
   if ( !this.canBeStatement && this.err('not.stmt') )

--- a/src/parse-export@Parser.js
+++ b/src/parse-export@Parser.js
@@ -19,19 +19,19 @@ this.parseExport = function() {
     if (this.ltraw !== '*' &&
         this.err('export.all.not.*',{extra:[startc,startLoc]}) )
       return this.errorHandlerOutput;
- 
+
     this.next();
     if ( !this.expectID_soft('from') &&
           this.err('export.all.no.from',{extra:[startc,startLoc]}) )
       return this.errorHandlerOutput;
 
     if (!(this.lttype === 'Literal' &&
-         typeof this.ltval === STRING_TYPE ) && 
+         typeof this.ltval === STRING_TYPE ) &&
          this.err('export.all.source.not.str',{extra:[startc,startLoc]}) )
       return this.errorHandlerOutput;
 
     src = this.numstr();
-    
+
     endI = this.semiI();
     semiLoc = this.semiLoc_soft();
     if ( !semiLoc && !this.newlineBeforeLookAhead &&
@@ -39,7 +39,7 @@ this.parseExport = function() {
       return this.errorHandlerOutput;
 
     this.foundStatement = true;
-    
+
     return  { type: 'ExportAllDeclaration',
                start: startc,
                loc: { start: startLoc, end: semiLoc || src.loc.end },
@@ -62,12 +62,12 @@ this.parseExport = function() {
        }
        ex = local;
        if ( this.lttype === 'Identifier' ) {
-         if ( this.ltval !== 'as' && 
+         if ( this.ltval !== 'as' &&
               this.err('export.specifier.not.as',{extra:[startc,startLoc,local,list]}) )
            return this.errorHandlerOutput ;
 
          this.next();
-         if ( this.lttype !== 'Identifier' ) { 
+         if ( this.lttype !== 'Identifier' ) {
             if (  this.err('export.specifier.after.as.id',{extra:[startc,startLoc,local,list]}) )
            return this.errorHandlerOutput;
          }
@@ -76,7 +76,7 @@ this.parseExport = function() {
        }
        list.push({ type: 'ExportSpecifier',
                   start: local.start,
-                  loc: { start: local.loc.start, end: ex.loc.end }, 
+                  loc: { start: local.loc.start, end: ex.loc.end },
                    end: ex.end, exported: ex,
                   local: local }) ;
 
@@ -88,8 +88,8 @@ this.parseExport = function() {
 
      endI = this.c;
      var li = this.li, col = this.col;
-  
-     if ( !this.expectType_soft('}') && 
+
+     if ( !this.expectType_soft('}') &&
            this.err('export.named.list.not.finished',{extra:[startc,startLoc,list,endI,li,col]}) )
        return this.errorHandlerOutput  ;
 
@@ -117,7 +117,7 @@ this.parseExport = function() {
      semiLoc = this.semiLoc_soft();
      if ( !semiLoc && !this.nl &&
           this.err('no.semi'))
-       return this.errorHandlerOutput; 
+       return this.errorHandlerOutput;
 
      this.foundStatement = true;
      return { type: 'ExportNamedDeclaration',
@@ -132,31 +132,31 @@ this.parseExport = function() {
 
   var context = CTX_NONE;
 
-  if ( this.lttype === 'Identifier' && 
+  if ( this.lttype === 'Identifier' &&
        this.ltval === 'default' ) {
     context = CTX_DEFAULT;
     if (this.onToken_ !== null)
       this.lttype = 'Keyword';
     this.next();
   }
-  
+
   if ( this.lttype === 'Identifier' ) {
       switch ( this.ltval ) {
          case 'let':
          case 'const':
-            if (context === CTX_DEFAULT && 
+            if (context === CTX_DEFAULT &&
                 this.err('export.default.const.let',{extra:[startc,startLoc]}) )
               return this.errorHandlerOutput;
-                
+
             this.canBeStatement = true;
             ex = this.parseVariableDeclaration(CTX_NONE);
             break;
-              
+
          case 'class':
             this.canBeStatement = true;
             ex = this.parseClass(context);
             break;
-  
+
          case 'var':
             this.canBeStatement = true;
             ex = this.parseVariableDeclaration(CTX_NONE ) ;
@@ -185,7 +185,7 @@ this.parseExport = function() {
              if (this.lttype === 'Identifier' && this.ltval === 'function') {
                ASSERT.call(this, this.nl, 'no newline before the "function" thing and still errors? -- impossible!');
                this.err('export.newline.before.the.function', {extra:[startc,startLoc]});
-             } 
+             }
              else
                this.err('export.async.but.no.function',{extra:[startc,startLoc]});
            }
@@ -196,7 +196,7 @@ this.parseExport = function() {
 
     if (!ex && this.err('export.named.no.exports',{extra:[startc,startLoc]}) )
       return this.errorHandlerOutput ;
-    
+
     this.foundStatement = true;
     return { type: 'ExportNamedDeclaration',
            start: startc,
@@ -223,8 +223,8 @@ this.parseExport = function() {
   }
 
   this.foundStatement = true;
-  return { type: 'ExportDefaultDeclaration',    
+  return { type: 'ExportDefaultDeclaration',
           start: startc,
           loc: { start: startLoc, end: endLoc || ex.loc.end },
            end: endI || ex.end, declaration: core( ex ) };
-}; 
+};

--- a/src/parse-expr-head@Parser.js
+++ b/src/parse-expr-head@Parser.js
@@ -1,4 +1,4 @@
-this.parseExprHead = function (context) {
+Parser.prototype.parseExprHead = function (context) {
   var head = null, inner = null, elem = null;
 
   if (this.pendingExprHead) {

--- a/src/parse-expr-head@Parser.js
+++ b/src/parse-expr-head@Parser.js
@@ -43,9 +43,9 @@ this.parseExprHead = function (context) {
 
     default:
       return null;
-   
+
     }
-    
+
   // #if V
   if (head.type === 'Identifier')
     this.scope.reference(head.name);
@@ -74,12 +74,12 @@ this.parseExprHead = function (context) {
       if (elem === null)
         this.err('mem.id.is.null');
 
-      head = { 
+      head = {
         type: 'MemberExpression', property: elem,
         start: head.start, end: elem.end,
         loc: {
           start: head.loc.start,
-          end: elem.loc.end 
+          end: elem.loc.end
         }, object: inner,
         computed: false /* ,y:-1*/
       };

--- a/src/parse-for@Parser.js
+++ b/src/parse-for@Parser.js
@@ -1,4 +1,4 @@
-this.parseFor = function() {
+Parser.prototype.parseFor = function() {
   if (!this.ensureStmt_soft())
     this.err('not.stmt');
 
@@ -144,7 +144,7 @@ this.parseFor = function() {
 };
 
 // TODO: exsureVarsAreNotResolvingToCatchParams_soft
-this.ensureVarsAreNotResolvingToCatchParams = function() {
+Parser.prototype.ensureVarsAreNotResolvingToCatchParams = function() {
   return;
 // #if V
   var list = this.scope.nameList, e = 0;

--- a/src/parse-for@Parser.js
+++ b/src/parse-for@Parser.js
@@ -45,7 +45,7 @@ this.parseFor = function() {
     headIsExpr = true;
     head = this.parseExpr( CTX_NULLABLE|CTX_PAT|CTX_FOR ) ;
   }
-  else 
+  else
     this.foundStatement = false;
 
   this.scope.exitForInit();
@@ -85,7 +85,7 @@ this.parseFor = function() {
       }
 
       this.next();
-      afterHead = kind === 'ForOfStatement' ? 
+      afterHead = kind === 'ForOfStatement' ?
         this.parseNonSeqExpr(PREC_WITH_NO_OP, CTX_NONE|CTX_PAT|CTX_NO_SIMPLE_ERR) :
         this.parseExpr(CTX_NONE|CTX_TOP);
 
@@ -135,7 +135,7 @@ this.parseFor = function() {
   this.exitScope();
 
   return {
-    type: 'ForStatement', init: head && core(head), 
+    type: 'ForStatement', init: head && core(head),
     start : startc, end: nbody.end,
     test: afterHead && core(afterHead),
     loc: { start: startLoc, end: nbody.loc.end },

--- a/src/parse-fun-new@Parser.js
+++ b/src/parse-fun-new@Parser.js
@@ -1,4 +1,4 @@
-this.parseFunc = function(context, st) {
+Parser.prototype.parseFunc = function(context, st) {
   var prevLabels = this.labels,
       prevDeclMode = this.declMode;
 
@@ -123,7 +123,7 @@ this.parseFunc = function(context, st) {
   return n;
 };
 
-this.parseFuncExprName = function() {
+Parser.prototype.parseFuncExprName = function() {
   var name = this.validateID("");
   if (this.scope.insideStrict() && arguments_or_eval(fnName.name))
     this.err('bind.eval.or.arguments');

--- a/src/parse-fun-new@Parser.js
+++ b/src/parse-fun-new@Parser.js
@@ -1,6 +1,6 @@
 this.parseFunc = function(context, st) {
   var prevLabels = this.labels,
-      prevDeclMode = this.declMode; 
+      prevDeclMode = this.declMode;
 
   var isStmt = false,
       startc = this.c0,

--- a/src/parse-funbody@Parser.js
+++ b/src/parse-funbody@Parser.js
@@ -1,6 +1,6 @@
 this.parseFuncBody = function(context) {
   var elem = null;
-  
+
   if ( this.lttype !== '{' ) {
     elem = this.parseNonSeqExpr(PREC_WITH_NO_OP, context|CTX_NULLABLE|CTX_PAT);
     if ( elem === null )

--- a/src/parse-funbody@Parser.js
+++ b/src/parse-funbody@Parser.js
@@ -1,4 +1,4 @@
-this.parseFuncBody = function(context) {
+Parser.prototype.parseFuncBody = function(context) {
   var elem = null;
 
   if ( this.lttype !== '{' ) {

--- a/src/parse-funparams@Parser.js
+++ b/src/parse-funparams@Parser.js
@@ -1,4 +1,4 @@
-this.parseArgs = function (argLen) {
+Parser.prototype.parseArgs = function (argLen) {
   var c0 = -1, li0 = -1, col0 = -1, tail = true,
       list = [], elem = null;
 

--- a/src/parse-id-or-id-stmt@Parser.js
+++ b/src/parse-id-or-id-stmt@Parser.js
@@ -21,7 +21,7 @@ this. parseIdStatementOrId = function ( context ) {
       // TODO: is it actually needed anymore?
       if ( context & CTX_FOR )
         return null;
- 
+
        this.notId() ;
     default: pendingExprHead = this.id(); break SWITCH ;
     }
@@ -73,7 +73,7 @@ this. parseIdStatementOrId = function ( context ) {
       this.resvchk(); this.kw();
       if ( this.canBeStatement )
          this.canBeStatement = false;
-      this.lttype = 'u'; 
+      this.lttype = 'u';
       this.isVDT = VDT_VOID;
       return null;
     case 'this':
@@ -131,7 +131,7 @@ this. parseIdStatementOrId = function ( context ) {
     case 'while':
       this.resvchk(); this.kw();
       return this.parseWhileStatement();
-    case 'yield': 
+    case 'yield':
       if (this.scope.canYield()) {
         this.resvchk();
         if (this.scope.isAnyFnHead())
@@ -147,7 +147,7 @@ this. parseIdStatementOrId = function ( context ) {
 
       pendingExprHead = this.id();
       break SWITCH;
-          
+
     case 'false':
       this.resvchk(); if (this.onToken_ !== null) this.lttype = 'Boolean';
       pendingExprHead = this.parseFalse();
@@ -193,11 +193,11 @@ this. parseIdStatementOrId = function ( context ) {
       this.resvchk(); this.kw();
       if ( this.canBeStatement )
         this.canBeStatement = false ;
-      this.lttype = 'u'; 
+      this.lttype = 'u';
       this.isVDT = id === 'delete' ? VDT_DELETE : VDT_VOID;
       return null;
 
-    case 'export': 
+    case 'export':
       this.resvchk(); this.kw();
       if ( this.isScript && this.err('export.not.in.module') )
         return this.errorHandlerOutput;
@@ -302,7 +302,7 @@ this. parseIdStatementOrId = function ( context ) {
 
   return pendingExprHead;
 };
- 
+
 this.resvchk = function() {
   if (this.esct !== ERR_NONE_YET) {
     ASSERT.call(this.esct === ERR_PIN_UNICODE_IN_RESV,

--- a/src/parse-id-or-id-stmt@Parser.js
+++ b/src/parse-id-or-id-stmt@Parser.js
@@ -1,5 +1,5 @@
-this . notId = function(id) { throw new Error ( 'not a valid id '   +   id )   ;  } ;
-this. parseIdStatementOrId = function ( context ) {
+Parser.prototype. notId = function(id) { throw new Error ( 'not a valid id '   +   id )   ;  } ;
+Parser.prototype. parseIdStatementOrId = function ( context ) {
   var id = this.ltval ;
   var pendingExprHead = null;
 
@@ -303,7 +303,7 @@ this. parseIdStatementOrId = function ( context ) {
   return pendingExprHead;
 };
 
-this.resvchk = function() {
+Parser.prototype.resvchk = function() {
   if (this.esct !== ERR_NONE_YET) {
     ASSERT.call(this.esct === ERR_PIN_UNICODE_IN_RESV,
       'the error in this.esct is something other than ERR_PIN_UNICODE_IN_RESV: ' + this.esct);

--- a/src/parse-id@Parser.js
+++ b/src/parse-id@Parser.js
@@ -1,4 +1,4 @@
-this.id = function() {
+Parser.prototype.id = function() {
   var id = {
     type: 'Identifier', name: this.ltval,
     start: this.c0, end: this.c,

--- a/src/parse-identifier@Parser.js
+++ b/src/parse-identifier@Parser.js
@@ -1,4 +1,4 @@
-this.readAnIdentifierToken = function (v) {
+Parser.prototype.readAnIdentifierToken = function (v) {
   var c = this.c, src = this.src, len = src.length, peek, start = c;
   c++; // start reading the body
 

--- a/src/parse-identifier@Parser.js
+++ b/src/parse-identifier@Parser.js
@@ -5,7 +5,7 @@ this.readAnIdentifierToken = function (v) {
   var byte2, startSlice = c; // the head is already supplied in v
 
   while ( c < len ) {
-    peek = src.charCodeAt(c); 
+    peek = src.charCodeAt(c);
     if ( isIDBody(peek) ) {
       c++;
       continue;
@@ -18,7 +18,7 @@ this.readAnIdentifierToken = function (v) {
         this.eloc.li0 = this.li;
         this.eloc.col0 = this.col + (c-start);
       }
-      if ( !v ) // if all previous characters have been non-u characters 
+      if ( !v ) // if all previous characters have been non-u characters
         v = src.charAt (startSlice-1); // v = IDHead
 
       if ( startSlice < c ) // if there are any non-u characters behind the current '\'
@@ -41,7 +41,7 @@ this.readAnIdentifierToken = function (v) {
          if ( !isIDBody(peek) &&
                this.err('id.esc.must.be.idbody',{extra:peek}) )
            return this.errorHandlerOutput;
-     
+
          v += fromcode(peek);
       }
       c = this.c;
@@ -52,7 +52,7 @@ this.readAnIdentifierToken = function (v) {
        if ( !v ) { v = src.charAt(startSlice-1); }
        if ( startSlice < c ) v += src.slice(startSlice,c) ;
        c++;
-       this.c = c; 
+       this.c = c;
        byte2 = this.peekTheSecondByte() ;
        if (!isIDBody(((peek-0x0D800 ) << 10) + (byte2-0x0DC00) + 0x010000) &&
             this.err('id.multi.must.be.idbody') )
@@ -63,7 +63,7 @@ this.readAnIdentifierToken = function (v) {
        c++;
        startSlice = c;
     }
-    else { break ; } 
+    else { break ; }
    }
    if ( v ) { // if we have come across at least one u character
       if ( startSlice < c ) // but all others that came after the last u-character have not been u-characters

--- a/src/parse-if@Parser.js
+++ b/src/parse-if@Parser.js
@@ -18,7 +18,7 @@ this.parseIfStatement = function () {
   this.err('if.has.no.closing.paren');
 
   var nbody = this. parseStatement (false);
-  var scope = this.exitScope(); 
+  var scope = this.exitScope();
 
   var alt = null;
   if ( this.lttype === 'Identifier' && this.ltval === 'else') {

--- a/src/parse-if@Parser.js
+++ b/src/parse-if@Parser.js
@@ -1,4 +1,4 @@
-this.parseIfStatement = function () {
+Parser.prototype.parseIfStatement = function () {
   if ( !this.ensureStmt_soft () && this.err('not.stmt') )
     return this.errorHandlerOutput;
 

--- a/src/parse-import@Parser.js
+++ b/src/parse-import@Parser.js
@@ -31,21 +31,21 @@ this.parseImport = function() {
   }
 
   var spStartc = 0, spStartLoc = null;
-  
-  if (hasMore) switch (this.lttype) {   
+
+  if (hasMore) switch (this.lttype) {
   case 'op':
     if (this.ltraw !== '*')
       this.err('import.namespace.specifier.not.*');
     else {
       spStartc = this.c - 1;
       spStartLoc = this.locOn(1);
-  
+
       this.next();
       if (!this.expectID_soft('as'))
         this.err('import.namespace.specifier.no.as');
       if (this.lttype !== 'Identifier')
         this.err('import.namespace.specifier.local.not.id');
- 
+
       local = this.validateID("");
       list.push({
         type: 'ImportNamespaceSpecifier',
@@ -56,27 +56,27 @@ this.parseImport = function() {
       });
     }
     break;
-  
+
   case '{':
     hasList = true;
     this.next();
     while ( this.lttype === 'Identifier' ) {
       local = this.id();
-      var im = local; 
+      var im = local;
       if ( this.lttype === 'Identifier' ) {
-        if ( this.ltval !== 'as' && 
+        if ( this.ltval !== 'as' &&
              this.err('import.specifier.no.as') )
           return this.errorHandlerOutput ;
- 
+
         this.next();
         if ( this.lttype !== 'Identifier' &&
              this.err('import.specifier.local.not.id') )
           return this.errorHandlerOutput ;
- 
+
         local = this.validateID("");
       }
       else this.validateID(local.name);
- 
+
       list.push({
         type: 'ImportSpecifier',
         start: im.start,
@@ -84,16 +84,16 @@ this.parseImport = function() {
         end: local.end, imported: im,
         local: local
       });
- 
+
       if ( this.lttype === ',' )
          this.next();
       else
-         break ;                                  
+         break ;
     }
- 
-    if (!this.expectType_soft('}')) 
+
+    if (!this.expectType_soft('}'))
       this.err('import.specifier.list.unfinished');
- 
+
     break ;
 
   default:
@@ -116,12 +116,12 @@ this.parseImport = function() {
      this.err('import.source.is.not.str');
 
    var src = this.numstr();
-   var endI = this.semiI() || src.end, 
+   var endI = this.semiI() || src.end,
        semiLoc = this.semiLoc_soft();
 
    if (!semiLoc && !this.nl)
      this.err('no.semi');
-   
+
    this.foundStatement = true;
 
    return {
@@ -134,4 +134,4 @@ this.parseImport = function() {
      end:  endI , specifiers: list,
      source: src
    };
-}; 
+};

--- a/src/parse-import@Parser.js
+++ b/src/parse-import@Parser.js
@@ -1,5 +1,5 @@
 // TODO: needs a thorough simplification
-this.parseImport = function() {
+Parser.prototype.parseImport = function() {
   if (this.v <= 5)
     this.err('ver.exim');
 

--- a/src/parse-labelled-stmt@Parser.js
+++ b/src/parse-labelled-stmt@Parser.js
@@ -1,4 +1,4 @@
-this .parseLabeledStatement = function(label, allowNull) {
+Parser.prototype.parseLabeledStatement = function(label, allowNull) {
    this.next();
    var l = label.name;
    l += '%';

--- a/src/parse-let@Parser.js
+++ b/src/parse-let@Parser.js
@@ -1,5 +1,5 @@
 
-this.parseLet = function(context) {
+Parser.prototype.parseLet = function(context) {
 
 // this function is only calld when we have a 'let' at the start of a statement,
 // or else when we have a 'let' at the start of a for's init; so, CTX_FOR means "at the start of a for's init ",
@@ -31,7 +31,7 @@ this.parseLet = function(context) {
   return null ;
 };
 
-this.hasDeclarator = function() {
+Parser.prototype.hasDeclarator = function() {
 
   switch (this.lttype) {
   case '[':

--- a/src/parse-let@Parser.js
+++ b/src/parse-let@Parser.js
@@ -38,7 +38,7 @@ this.hasDeclarator = function() {
   case '{':
   case 'Identifier':
     return true;
-  
+
   default:
     return false;
 

--- a/src/parse-literal@Parser.js
+++ b/src/parse-literal@Parser.js
@@ -1,4 +1,4 @@
-this.numstr = function () {
+Parser.prototype.numstr = function () {
   var n = {
     type: 'Literal', value: this.ltval,
     start: this.c0, end: this.c,
@@ -9,7 +9,7 @@ this.numstr = function () {
   return n;
 };
 
-this.parseTrue = function() {
+Parser.prototype.parseTrue = function() {
   var n = {
     type: 'Literal', value: true,
     start: this.c0, end: this.c,
@@ -19,7 +19,7 @@ this.parseTrue = function() {
   return n;
 };
 
-this.parseNull = function() {
+Parser.prototype.parseNull = function() {
   var n = {
     type: 'Literal', value: null,
     start: this.c0, end: this.c,
@@ -29,7 +29,7 @@ this.parseNull = function() {
   return n;
 };
 
-this.parseFalse = function() {
+Parser.prototype.parseFalse = function() {
   var n = {
     type: 'Literal', value: false,
     start: this.c0, end: this.c,

--- a/src/parse-mem@Parser.js
+++ b/src/parse-mem@Parser.js
@@ -15,7 +15,7 @@ function assembleID(c0, li0, col0, raw, val) {
   }
 }
 
-this.parseMem = function(context, st) {
+Parser.prototype.parseMem = function(context, st) {
   var c0 = 0, li0 = 0, col0 = 0, nmod = 0,
       nli0 = 0, nc0 = 0, ncol0 = 0, nraw = "", nval = "", latestFlag = 0;
 
@@ -167,7 +167,7 @@ this.parseMem = function(context, st) {
   return this.parseObjElem(nmem, context);
 };
 
-this.parseObjElem = function(name, context) {
+Parser.prototype.parseObjElem = function(name, context) {
   var hasProto = context & CTX_HASPROTO, firstProto = this.first__proto__;
   var val = null;
   context &= ~CTX_HASPROTO;

--- a/src/parse-mem@Parser.js
+++ b/src/parse-mem@Parser.js
@@ -4,10 +4,10 @@
 // value of the `raw` param is known to be either 'static', 'get', or 'set';
 // but if this is going to be called for any value of raw containing surrogates, it may not work correctly.
 function assembleID(c0, li0, col0, raw, val) {
-  return { 
+  return {
     type: 'Identifier', raw: raw,
     name: val, end: c0 + raw.length,
-    start: c0, 
+    start: c0,
     loc: {
       start: { line: li0, column: col0 },
       end: { line: li0, column: col0 + raw.length }
@@ -21,7 +21,7 @@ this.parseMem = function(context, st) {
 
   var asyncNewLine = false;
   if (this.v > 5 && this.lttype === 'Identifier') {
-    LOOP:  
+    LOOP:
     // TODO: check version number when parsing get/set
     do {
       if (nmod === 0) {
@@ -52,7 +52,7 @@ this.parseMem = function(context, st) {
         nc0 = this.c0; nli0 = this.li0;
         ncol0 = this.col0; nraw = this.ltraw;
         nval = this.ltval;
-        
+
         st |= latestFlag = this.ltval === 'get' ? ST_GETTER : ST_SETTER;
         nmod++;
         this.next();
@@ -82,7 +82,7 @@ this.parseMem = function(context, st) {
       }
     } while (this.lttype === 'Identifier');
   }
-  
+
   if (this.lttype === 'op' && this.ltraw === '*') {
     if (this.v <= 5)
       this.err('ver.mem.gen');
@@ -142,7 +142,7 @@ this.parseMem = function(context, st) {
     if (st & ST_GEN)
       this.err('mem.gen.has.no.name');
     return null;
-  } 
+  }
 
   if (this.lttype === '(') {
     if (this.v <= 5) this.err('ver.mem.meth');
@@ -166,7 +166,7 @@ this.parseMem = function(context, st) {
 
   return this.parseObjElem(nmem, context);
 };
- 
+
 this.parseObjElem = function(name, context) {
   var hasProto = context & CTX_HASPROTO, firstProto = this.first__proto__;
   var val = null;
@@ -209,7 +209,7 @@ this.parseObjElem = function(name, context) {
       this.first__proto__ = val;
 
     return val;
- 
+
   case 'op':
     if (this.v <= 5)
       this.err('mem.short.assig');
@@ -225,7 +225,7 @@ this.parseObjElem = function(name, context) {
        this.st === ERR_NONE_YET) {
       this.st = ERR_SHORTHAND_UNASSIGNED; this.se = val;
     }
- 
+
     break;
 
   default:
@@ -237,7 +237,7 @@ this.parseObjElem = function(name, context) {
     val = name;
     break;
   }
-  
+
   return {
     type: 'Property', key: name,
     start: val.start, end: val.end,

--- a/src/parse-memname@Parser.js
+++ b/src/parse-memname@Parser.js
@@ -1,5 +1,5 @@
-this .memberID = function() { return this.v > 5 ? this.id() : this.validateID("") ; };
-this .memberExpr = function() {
+Parser.prototype.memberID = function() { return this.v > 5 ? this.id() : this.validateID("") ; };
+Parser.prototype.memberExpr = function() {
   if (this.v <= 5)
     this.err('ver.mem.comp');
 

--- a/src/parse-memname@Parser.js
+++ b/src/parse-memname@Parser.js
@@ -6,24 +6,24 @@ this .memberExpr = function() {
   var startc = this.c - 1,
       startLoc = this.locOn(1);
   this.next() ;
-  
+
   // none of the modifications memberExpr may make to this.pt, this.at, and this.st
   // overwrite some other unrecorded this.pt, this.at, or this.st -- an unrecorded value of <pt:at:st>
   // means a whole elem was just parsed, and <pt:at:st> is immediately recorded after that whole
   // potpat element is parsed, so if a memberExpr overwrites <pt:at:st>, that <pt:at:st> is not an
   // unrecorded one.
-  
+
   // TODO: it is not necessary to reset <pt:at>
   this.pt = this.at = this.st = 0;
-  var e = this.parseNonSeqExpr(PREC_WITH_NO_OP, CTX_NONE|CTX_PAT|CTX_NO_SIMPLE_ERR); // TODO: should be CTX_NULLABLE, or else the next line is in vain 
-  if (!e && this.err('prop.dyna.no.expr') ) // 
+  var e = this.parseNonSeqExpr(PREC_WITH_NO_OP, CTX_NONE|CTX_PAT|CTX_NO_SIMPLE_ERR); // TODO: should be CTX_NULLABLE, or else the next line is in vain
+  if (!e && this.err('prop.dyna.no.expr') ) //
     return this.errorHandlerOutput ;
 
   var n = { type: PAREN, expr: e, start: startc, end: this.c, loc: { start: startLoc, end: this.loc() } } ;
   if ( !this.expectType_soft (']') &&
         this.err('prop.dyna.is.unfinished') )
     return this.errorHandlerOutput ;
- 
+
   return n;
 };
 

--- a/src/parse-meta@Parser.js
+++ b/src/parse-meta@Parser.js
@@ -1,5 +1,5 @@
 // TODO: new_raw
-this.parseMeta = function(startc,end,startLoc,endLoc,new_raw ) {
+Parser.prototype.parseMeta = function(startc,end,startLoc,endLoc,new_raw ) {
   if (this.ltval !== 'target')
     this.err('meta.new.has.unknown.prop');
 

--- a/src/parse-meta@Parser.js
+++ b/src/parse-meta@Parser.js
@@ -2,7 +2,7 @@
 this.parseMeta = function(startc,end,startLoc,endLoc,new_raw ) {
   if (this.ltval !== 'target')
     this.err('meta.new.has.unknown.prop');
-  
+
   if (!this.scope.canHaveNewTarget())
     this.err('meta.new.not.in.function',{c0:startc,loc:startLoc});
 
@@ -13,7 +13,7 @@ this.parseMeta = function(startc,end,startLoc,endLoc,new_raw ) {
     meta: {
       type: 'Identifier', name : 'new',
       start: startc, end: end,
-      loc: { start : startLoc, end: endLoc }, raw: new_raw  
+      loc: { start : startLoc, end: endLoc }, raw: new_raw
     },
     start : startc,
     property: prop, end: prop.end,

--- a/src/parse-meth-like@Parser.js
+++ b/src/parse-meth-like@Parser.js
@@ -34,7 +34,7 @@ this.parseMeth = function(name, context, st) {
       value: val, 'static': !!(st & ST_STATICMEM)/* ,y:-1*/
     }
   }
-   
+
   val = this.parseFunc(CTX_NONE, st);
 
   return {

--- a/src/parse-meth-like@Parser.js
+++ b/src/parse-meth-like@Parser.js
@@ -1,4 +1,4 @@
-this.parseMeth = function(name, context, st) {
+Parser.prototype.parseMeth = function(name, context, st) {
   if (this.lttype !== '(')
     this.err('meth.paren');
   var val = null;

--- a/src/parse-new@Parser.js
+++ b/src/parse-new@Parser.js
@@ -1,4 +1,4 @@
-this.parseNewHead = function () {
+Parser.prototype.parseNewHead = function () {
   var startc = this.c0, end = this.c,
       startLoc = this.locBegin(), li = this.li,
       col = this.col, raw = this.ltraw ;

--- a/src/parse-new@Parser.js
+++ b/src/parse-new@Parser.js
@@ -72,7 +72,7 @@ this.parseNewHead = function () {
       if ( !this.expectType_soft (']') ) {
         this.err('mem.unfinished')  ;
       }
- 
+
       continue;
 
     case '(':

--- a/src/parse-non-seq@Parser.js
+++ b/src/parse-non-seq@Parser.js
@@ -12,17 +12,17 @@ this.parseNonSeqExpr = function (prec, context) {
        break;
 
     case 'yield':
-      // make sure there is no other expression before it 
-      if (prec !== PREC_WITH_NO_OP) 
+      // make sure there is no other expression before it
+      if (prec !== PREC_WITH_NO_OP)
         return this.err('yield.as.an.id');
 
-      // everything that comes belongs to it 
-      return this.parseYield(context); 
- 
+      // everything that comes belongs to it
+      return this.parseYield(context);
+
     default:
       if (!(context & CTX_NULLABLE) )
         return this.err('nexpr.null.head');
-       
+
       return null;
     }
   }
@@ -41,7 +41,7 @@ this.parseNonSeqExpr = function (prec, context) {
       this.currentExprIsSimple();
       this.dissolveParen();
   }
-  
+
   if (!op || assig)
     return head;
 
@@ -57,11 +57,11 @@ this.parseNonSeqExpr = function (prec, context) {
     if ( isMMorAA(currentPrec) ) {
       if (this.nl )
         break;
-    
+
       head = this.parseUpdateExpression(head, context);
       continue;
     }
-    
+
     if (prec === PREC_U && currentPrec === PREC_EX)
       this.err('unary.before.an.exponentiation');
     if (currentPrec < prec)

--- a/src/parse-non-seq@Parser.js
+++ b/src/parse-non-seq@Parser.js
@@ -1,4 +1,4 @@
-this.parseNonSeqExpr = function (prec, context) {
+Parser.prototype.parseNonSeqExpr = function (prec, context) {
   var head = this.parseExprHead(context);
   if ( head === null ) {
     switch ( this.lttype ) {

--- a/src/parse-number@Parser.js
+++ b/src/parse-number@Parser.js
@@ -34,12 +34,12 @@ this.readNumberLiteral = function (peek) {
         b = src.charCodeAt(c);
         if ( b !== CH_0 && b !== CH_1 && this.err('num.with.first.not.valid',{extra:'binary'}) )
           return this.errorHandlerOutput ;
-        val = b - CH_0; 
+        val = b - CH_0;
         ++c;
         while ( c < len &&
               ( b = src.charCodeAt(c), b === CH_0 || b === CH_1 ) ) {
            val <<= 1;
-           val |= b - CH_0; 
+           val |= b - CH_0;
            c++ ;
         }
         this.ltval = val ;
@@ -52,19 +52,19 @@ this.readNumberLiteral = function (peek) {
           this.err('ver.oct');
         ++c;
         if (c >= len && this.err('num.with.no.digits',{extra:'octal'}) )
-          return this.errorHandlerOutput ; 
+          return this.errorHandlerOutput ;
         b = src.charCodeAt(c);
         if ( (b < CH_0 || b >= CH_8) && this.err('num.with.first.not.valid',{extra:'octal'})  )
           return this.errorHandlerOutput ;
 
         val = b - CH_0 ;
-        ++c; 
+        ++c;
         while ( c < len &&
               ( b = src.charCodeAt(c), b >= CH_0 && b < CH_8 ) ) {
            val <<= (1 + 2);
            val |= b - CH_0;
            c++ ;
-        } 
+        }
         this.ltval = val ;
         this.ltraw = src.slice(this.c,c) ;
         this.c = c;
@@ -79,13 +79,13 @@ this.readNumberLiteral = function (peek) {
             c ++;
           } while ( c < len &&
                   ( b = src.charCodeAt(c), b >= CH_0 && b <= CH_9) );
-          
+
           b = this.c;
-          this.c = c; 
-  
+          this.c = c;
+
           if ( !this.frac(b) )
             this.ltval = parseInt (this.ltraw = src.slice(b, c), base);
-          
+
         }
         else {
           b = this.c ;
@@ -109,7 +109,7 @@ this.readNumberLiteral = function (peek) {
     }
   }
   // needless as it will be an error nevertheless, but it is still requir'd
-  if ( ( this.c < len && isIDHead(src.charCodeAt(this.c))) ) this.err('num.idhead.tail') ; 
+  if ( ( this.c < len && isIDHead(src.charCodeAt(this.c))) ) this.err('num.idhead.tail') ;
 };
 
 this . frac = function(n) {

--- a/src/parse-number@Parser.js
+++ b/src/parse-number@Parser.js
@@ -1,4 +1,4 @@
-this.readNumberLiteral = function (peek) {
+Parser.prototype.readNumberLiteral = function (peek) {
   var c = this.c, src = this.src, len = src.length;
   var b = 10 , val = 0;
   this.lttype  = 'Literal' ;
@@ -112,7 +112,7 @@ this.readNumberLiteral = function (peek) {
   if ( ( this.c < len && isIDHead(src.charCodeAt(this.c))) ) this.err('num.idhead.tail') ;
 };
 
-this . frac = function(n) {
+Parser.prototype. frac = function(n) {
   var c = this.c,
       l = this.src,
       e = l.length ;

--- a/src/parse-obj@Parser.js
+++ b/src/parse-obj@Parser.js
@@ -14,7 +14,7 @@ this.parseObjectExpression = function(context) {
     elemContext |= context & CTX_PARPAT;
     elemContext |= context & CTX_PARPAT_ERR;
   }
-  else 
+  else
     elemContext |= CTX_PAT|CTX_NO_SIMPLE_ERR;
 
   if (context & CTX_PARPAT) {
@@ -30,7 +30,7 @@ this.parseObjectExpression = function(context) {
       this.st = ERR_NONE_YET; this.se = this.so = null;
     }
   }
-  
+
   var pc0 = -1, pli0 = -1, pcol0 = -1;
   var ac0 = -1, ali0 = -1, acol0 = -1;
   var sc0 = -1, sli0 = -1, scol0 = -1;

--- a/src/parse-obj@Parser.js
+++ b/src/parse-obj@Parser.js
@@ -1,4 +1,4 @@
-this.parseObjectExpression = function(context) {
+Parser.prototype.parseObjectExpression = function(context) {
   var startc = this.c0,
       startLoc = this.locBegin(),
       elem = null,

--- a/src/parse-paren@Parser.js
+++ b/src/parse-paren@Parser.js
@@ -1,4 +1,4 @@
-this.parseParen = function(context) {
+Parser.prototype.parseParen = function(context) {
   var startc = this.c0,
       startLoc = this.locBegin(),
       elem = null,
@@ -179,7 +179,7 @@ this.parseParen = function(context) {
   return n;
 };
 
-this.dissolveParen = function() {
+Parser.prototype.dissolveParen = function() {
   if (this.parenScope) {
     this.parenScope.dissolve();
     this.parenScope = null;

--- a/src/parse-paren@Parser.js
+++ b/src/parse-paren@Parser.js
@@ -43,9 +43,9 @@ this.parseParen = function(context) {
       else if (list) {
         if (this.v < 7)
           this.err('seq.non.tail.expr');
-        else 
+        else
           hasTailElem = true;
-      } 
+      }
       else break;
     }
 
@@ -129,7 +129,7 @@ this.parseParen = function(context) {
         loc: {
           start: list[0].loc.start,
           end: list[list.length-1].loc.end
-        } 
+        }
       } : elem && core(elem),
       start: startc,
       end: this.c,

--- a/src/parse-pat-array@Parser.js
+++ b/src/parse-pat-array@Parser.js
@@ -21,18 +21,18 @@ this. parseArrayPattern = function() {
          if ( this.lttype === '...' ) {
            list.push(this.parseRestElement());
            break ;
-         }  
+         }
       }
-    
+
       if ( this.lttype === ',' ) {
          list.push(elem);
          this.next();
-      }       
+      }
       else  {
          if ( elem ) list.push(elem);
          break ;
       }
-  } 
+  }
 
   elem = { type: 'ArrayPattern', loc: { start: startLoc, end: this.loc() },
            start: startc, end: this.c, elements : list/* ,y:-1*/};

--- a/src/parse-pat-array@Parser.js
+++ b/src/parse-pat-array@Parser.js
@@ -1,4 +1,4 @@
-this. parseArrayPattern = function() {
+Parser.prototype. parseArrayPattern = function() {
   if (this.v <= 5)
     this.err('ver.patarr');
 

--- a/src/parse-pat-assig@Parser.js
+++ b/src/parse-pat-assig@Parser.js
@@ -1,4 +1,4 @@
-this .parseAssig = function (head) {
+Parser.prototype.parseAssig = function (head) {
   if (this.v <= 5)
     this.err('ver.assig');
   this.next() ;

--- a/src/parse-pat-obj@Parser.js
+++ b/src/parse-pat-obj@Parser.js
@@ -1,4 +1,4 @@
-this.parseObjectPattern  = function() {
+Parser.prototype.parseObjectPattern  = function() {
     if (this.v <= 5)
       this.err('ver.patobj');
 

--- a/src/parse-pat-obj@Parser.js
+++ b/src/parse-pat-obj@Parser.js
@@ -52,7 +52,7 @@ this.parseObjectPattern  = function() {
       }
 
       // TODO: this is a subtle case that was only lately noticed;
-      // parsePattern must have a way to throw when the pattern is not supposed to be null 
+      // parsePattern must have a way to throw when the pattern is not supposed to be null
       if (val === null)
         this.err('obj.prop.is.null');
 

--- a/src/parse-pat-rest@Parser.js
+++ b/src/parse-pat-rest@Parser.js
@@ -1,5 +1,5 @@
 // TODO: needs reconsideration,
-this.parseRestElement = function() {
+Parser.prototype.parseRestElement = function() {
    if (this.v <= 5)
      this.err('ver.spread.rest');
    var startc = this.c0,

--- a/src/parse-pattern@Parser.js
+++ b/src/parse-pattern@Parser.js
@@ -1,4 +1,4 @@
-this.parsePattern = function() {
+Parser.prototype.parsePattern = function() {
   switch ( this.lttype ) {
     case 'Identifier' :
        var id = this.validateID("");

--- a/src/parse-program@Parser.js
+++ b/src/parse-program@Parser.js
@@ -6,8 +6,8 @@ this.parseProgram = function () {
   // #if V
   globalScope = new GlobalScope();
   // #end
- 
-  this.directive = !this.isScipt ? DIR_SCRIPT : DIR_MODULE; 
+
+  this.directive = !this.isScipt ? DIR_SCRIPT : DIR_MODULE;
   this.clearAllStrictErrors();
 
   this.scope = new Scope(globalScope, ST_SCRIPT);
@@ -17,7 +17,7 @@ this.parseProgram = function () {
 
   this.next();
 
-  var list = this.blck(); 
+  var list = this.blck();
 
   this.scope.finish();
   globalScope.finish();

--- a/src/parse-program@Parser.js
+++ b/src/parse-program@Parser.js
@@ -1,4 +1,4 @@
-this.parseProgram = function () {
+Parser.prototype.parseProgram = function () {
   var startc = this.c, li = this.li, col = this.col;
   var endI = this.c , startLoc = null;
   var globalScope = null;

--- a/src/parse-regex@Parser.js
+++ b/src/parse-regex@Parser.js
@@ -27,12 +27,12 @@ function regexReplace(matchedString, b, noB, matchIndex, wholeString) {
   var c = parseInt('0x' + ( b || noB ) ) ;
   if (c > 0x010FFFF )
     this.err('regex.val.not.in.range');
-  
+
   if ( c <= 0xFFFF ) return String.fromCharCode(c) ;
 
   c -= 0x010000;
   return '\uFFFF';
-} 
+}
 
 function verifyRegex(regex, flags) {
   var regexVal = null;
@@ -71,7 +71,7 @@ this.parseRegExpLiteral = function() {
          case CH_BACK_SLASH:
             ++c;
             if (c < len) switch(src.charCodeAt(c)) {
-               case CH_CARRIAGE_RETURN: 
+               case CH_CARRIAGE_RETURN:
                   if ( l.charCodeAt(c + 1) === CH_LINE_FEED ) c++;
                case CH_LINE_FEED :
                case 0x2028 :
@@ -107,7 +107,7 @@ this.parseRegExpLiteral = function() {
        c++ ;
      }
 
-     if ( src.charCodeAt(c) !== CH_DIV && 
+     if ( src.charCodeAt(c) !== CH_DIV &&
           this.err('regex.unfinished') )
        return this.errorHandlerOutput ;
 
@@ -150,12 +150,12 @@ this.parseRegExpLiteral = function() {
      // those that contain a 'u' flag need special treatment when RegExp constructor they get sent to
      // doesn't support the 'u' flag: since they can have surrogate pair sequences (which are not allowed without the 'u' flag),
      // they must be checked for having such surrogate pairs, and should replace them with a character that is valid even
-     // without being in the context of a 'u' 
+     // without being in the context of a 'u'
      if ( (flags & uRegexFlag) && !(regexFlagsSupported & uRegexFlag) )
           normalizedRegex = normalizedRegex.replace( /\\u\{([A-F0-9a-f]+)\}/g, curlyReplace) // normalize curlies
              .replace( /\\u([A-F0-9a-f][A-F0-9a-f][A-F0-9a-f][A-F0-9a-f])/g, regexReplace ) // convert u
              .replace( /[\ud800-\udbff][\udc00-\udfff]/g, '\uFFFF' );
-       
+
 
      // all of the 1 bits in flags must also be 1 in the same bit index in regexsupportedFlags;
      // flags ^ rsf returns a bit set in which the 1 bits mean "this flag is either not used in flags, or yt is not supported";
@@ -174,7 +174,7 @@ this.parseRegExpLiteral = function() {
      this.col += (c-this.c);
      var regex = { type: 'Literal', regex: { pattern: patternString, flags: flagsString },
                    start: startc, end: c,
-                   value: val, loc: { start: startLoc, end: this.loc() }, 
+                   value: val, loc: { start: startLoc, end: this.loc() },
                    raw: this.src.substring(startc, c) };
      this.c = c;
 

--- a/src/parse-regex@Parser.js
+++ b/src/parse-regex@Parser.js
@@ -52,7 +52,7 @@ function verifyRegex_soft (regex, flags) {
 
 }
 
-this.parseRegExpLiteral = function() {
+Parser.prototype.parseRegExpLiteral = function() {
   if (this.v < 2)
     this.err('ver.regex');
      var startc = this.c - 1, startLoc = this.locOn(1),

--- a/src/parse-return@Parser.js
+++ b/src/parse-return@Parser.js
@@ -1,4 +1,4 @@
-this.parseReturnStatement = function () {
+Parser.prototype.parseReturnStatement = function () {
   if (! this.ensureStmt_soft () &&
        this.err('not.stmt') )
     return this.errorHandlerOutput ;

--- a/src/parse-spread@Parser.js
+++ b/src/parse-spread@Parser.js
@@ -11,7 +11,7 @@ this.parseSpreadElement = function(context) {
 
   if (e.type === PAREN_NODE) {
     if ((context & CTX_PARAM) && !(context & CTX_HAS_A_PARAM_ERR) &&
-       this.pt === ERR_NONE_YET) { 
+       this.pt === ERR_NONE_YET) {
       this.pt = ERR_PAREN_UNBINDABLE; this.pe = e;
     }
     if ((context & CTX_PAT) && !(context & CTX_HAS_AN_ASSIG_ERR) &&
@@ -19,7 +19,7 @@ this.parseSpreadElement = function(context) {
       this.at = ERR_PAREN_UNBINDABLE; this.ae = e;
     }
   }
-    
+
   return {
     type: 'SpreadElement',
     loc: { start: startLoc, end: e.loc.end },

--- a/src/parse-spread@Parser.js
+++ b/src/parse-spread@Parser.js
@@ -1,4 +1,4 @@
-this.parseSpreadElement = function(context) {
+Parser.prototype.parseSpreadElement = function(context) {
   if (this.v <= 5) this.err('ver.spread.rest');
 
   var startc = this.c0;

--- a/src/parse-stmt@Parser.js
+++ b/src/parse-stmt@Parser.js
@@ -1,4 +1,4 @@
-this.parseStatement = function ( allowNull ) {
+Parser.prototype.parseStatement = function ( allowNull ) {
   var head = null,
       l,
       e ,

--- a/src/parse-stmt@Parser.js
+++ b/src/parse-stmt@Parser.js
@@ -56,9 +56,9 @@ this.parseStatement = function ( allowNull ) {
         ASSERT.call(this.directive === DIR_NONE,
           'an expression that is going to become a statement must have set a non-null directive to none if it has not handled it');
         this.gotDirective(this.dv, directive);
- 
+
         // so that the escaped octals are recorded if the next token to be extracted is a string literal
-        this.directive = directive; 
+        this.directive = directive;
       }
     }
     if (esct !== ERR_NONE_YET && this.se === null)
@@ -70,7 +70,7 @@ this.parseStatement = function ( allowNull ) {
   if ( !l && !this.nl &&
        this.err('no.semi') )
     return this.errorHandlerOutput;
- 
+
   return {
     type : 'ExpressionStatement',
     expression : core(head),

--- a/src/parse-string@Parser.js
+++ b/src/parse-string@Parser.js
@@ -1,4 +1,4 @@
-this.readStrLiteral = function (start) {
+Parser.prototype.readStrLiteral = function (start) {
   var c = this.c += 1,
       l = this.src,
       e = l.length,

--- a/src/parse-switch-case@Parser.js
+++ b/src/parse-switch-case@Parser.js
@@ -1,4 +1,4 @@
-this.parseSwitchCase = function () {
+Parser.prototype.parseSwitchCase = function () {
   var startc,
       startLoc;
 

--- a/src/parse-switch@Parser.js
+++ b/src/parse-switch@Parser.js
@@ -22,7 +22,7 @@ this.parseSwitchStatement = function () {
   !this.expectType_soft ('{') &&
   this.err('switch.has.no.opening.curly');
 
-  this.enterScope(this.scope.blockScope()); 
+  this.enterScope(this.scope.blockScope());
   this.allow(SA_BREAK);
 
   while ( elem = this.parseSwitchCase()) {
@@ -34,7 +34,7 @@ this.parseSwitchStatement = function () {
   }
 
   this.foundStatement = true;
-  var scope = this.exitScope(); 
+  var scope = this.exitScope();
 
   var n = { type: 'SwitchStatement', cases: cases, start: startc, discriminant: switchExpr,
             end: this.c, loc: { start: startLoc, end: this.loc() }/*,scope:  scope  ,y:-1*/};

--- a/src/parse-switch@Parser.js
+++ b/src/parse-switch@Parser.js
@@ -1,4 +1,4 @@
-this.parseSwitchStatement = function () {
+Parser.prototype.parseSwitchStatement = function () {
   if (!this.ensureStmt_soft())
     this.err('not.stmt');
 

--- a/src/parse-template@Parser.js
+++ b/src/parse-template@Parser.js
@@ -6,31 +6,31 @@ this . parseTemplateLiteral = function() {
   var startc = this.c - 1, startLoc = this.locOn(1);
   var c = this.c, src = this.src, len = src.length;
   var templStr = [], templExpressions = [];
-  
+
   // an element's content might get fragmented by an esc appearing in it,
   // e.g., 'eeeee\nee' has two fragments, 'eeeee' and 'ee'
-  var startElemFragment = c; 
+  var startElemFragment = c;
 
   var startElem = c,
       currentElemContents = "",
       startColIndex = c ,
       ch = 0, elem = null;
- 
+
   while ( c < len ) {
     ch = src.charCodeAt(c);
-    if ( ch === CH_BACKTICK ) break; 
+    if ( ch === CH_BACKTICK ) break;
     switch ( ch ) {
        case CH_$ :
           if ( src.charCodeAt(c+1) === CH_LCURLY ) {
               currentElemContents += src.slice(startElemFragment, c) ;
               this.col += ( c - startColIndex );
               elem =
-                { type: 'TemplateElement', 
+                { type: 'TemplateElement',
                  start: startElem, end: c, tail: false,
-                 loc: { start: { line: li, column: col }, end: { line: this.li, column: this.col } },        
-                 value: { raw : src.slice(startElem, c ).replace(/\r\n|\r/g,'\n'), 
+                 loc: { start: { line: li, column: col }, end: { line: this.li, column: this.col } },
+                 value: { raw : src.slice(startElem, c ).replace(/\r\n|\r/g,'\n'),
                         cooked: currentElemContents   } };
-              
+
               templStr.push(elem);
 
               if (this.onToken_ !== null) {
@@ -49,10 +49,10 @@ this . parseTemplateLiteral = function() {
               this.c = c + 2; // ${
               this.col += 2; // ${
 
-              // this must be done manually because we must have                       
+              // this must be done manually because we must have
               // a lookahead before starting to parse an actual expression
-              this.next(); 
-                           
+              this.next();
+
               templExpressions.push( core(this.parseExpr(CTX_NONE)) );
               if ( this. lttype !== '}')
                 this.err('templ.expr.is.unfinished') ;
@@ -69,7 +69,7 @@ this . parseTemplateLiteral = function() {
 
           continue;
 
-       case CH_CARRIAGE_RETURN: 
+       case CH_CARRIAGE_RETURN:
            currentElemContents += src.slice(startElemFragment,c) + '\n' ;
            c++;
            if ( src.charCodeAt(c) === CH_LINE_FEED ) c++;
@@ -77,39 +77,39 @@ this . parseTemplateLiteral = function() {
            this.li++;
            this.col = 0;
            continue ;
- 
+
        case CH_LINE_FEED:
            currentElemContents += src.slice(startElemFragment,c) + '\n';
            c++;
            startElemFragment = startColIndex = c;
            this.li++;
            this.col = 0;
-           continue; 
- 
+           continue;
+
        case 0x2028: case 0x2029:
            currentElemContents += src.slice(startElemFragment,c) + src.charAt(c);
            startColIndex = c;
-           c++; 
+           c++;
            startElemFragment = c;
            this.li++;
-           this.col = 0;           
+           this.col = 0;
            continue ;
- 
+
        case CH_BACK_SLASH :
-           this.c = c; 
+           this.c = c;
            currentElemContents += src.slice( startElemFragment, c ) + this.readStrictEsc();
            c  = this.c;
            c++;
-           if ( this.col === 0 ) // if we had an escaped newline 
+           if ( this.col === 0 ) // if we had an escaped newline
              startColIndex = c;
-           
+
            startElemFragment = c ;
            continue ;
     }
 
     c++ ;
   }
-  
+
   if ( startElem < c ) {
      this.col += ( c - startColIndex );
      if ( startElemFragment < c )
@@ -123,7 +123,7 @@ this . parseTemplateLiteral = function() {
      loc: { start : { line: li, column: col }, end: { line: this.li, column: this.col } },
      end: startElem < c ? c : startElem ,
      tail: true,
-     value: { raw: src.slice(startElem,c).replace(/\r\n|\r/g,'\n'), 
+     value: { raw: src.slice(startElem,c).replace(/\r\n|\r/g,'\n'),
               cooked: currentElemContents }
   };
 
@@ -136,12 +136,12 @@ this . parseTemplateLiteral = function() {
       loc: {
         start: { line: elem.loc.start.line, column: elem.loc.start.column-1 },
         end: { line: elem.loc.end.line, column: elem.loc.end.column+1 }
-      }    
+      }
     });
     this.lttype = "";
   }
 
-  c++; // backtick  
+  c++; // backtick
   this.col ++ ;
 
   var n = { type: 'TemplateLiteral', start: startc, quasis: templStr, end: c,
@@ -150,7 +150,7 @@ this . parseTemplateLiteral = function() {
   if ( ch !== CH_BACKTICK ) this.err('templ.lit.is.unfinished',{extra:n}) ;
 
   this.c = c;
-  this.next(); // prepare the next token  
+  this.next(); // prepare the next token
 
   return n
 };

--- a/src/parse-template@Parser.js
+++ b/src/parse-template@Parser.js
@@ -1,4 +1,4 @@
-this . parseTemplateLiteral = function() {
+Parser.prototype. parseTemplateLiteral = function() {
   if (this.v <= 5)
     this.err('ver.temp');
 

--- a/src/parse-this@Parser.js
+++ b/src/parse-this@Parser.js
@@ -1,4 +1,4 @@
-this.parseThis = function() {
+Parser.prototype.parseThis = function() {
   var n = {
     type : 'ThisExpression',
     loc: { start: this.locBegin(), end: this.loc() },

--- a/src/parse-throw@Parser.js
+++ b/src/parse-throw@Parser.js
@@ -1,4 +1,4 @@
-this.parseThrowStatement = function () {
+Parser.prototype.parseThrowStatement = function () {
   if ( ! this.ensureStmt_soft () &&
          this.err('not.stmt') )
     return this.errorHandlerOutput ;

--- a/src/parse-top-level-expr@Parser.js
+++ b/src/parse-top-level-expr@Parser.js
@@ -1,4 +1,4 @@
-this.parseExpr = function (context) {
+Parser.prototype.parseExpr = function (context) {
   var head = this.parseNonSeqExpr(PREC_WITH_NO_OP, context);
   var lastExpr = null;
 

--- a/src/parse-tryblock@Parser.js
+++ b/src/parse-tryblock@Parser.js
@@ -9,9 +9,9 @@ this.parseTryStatement = function () {
 
   this.next() ;
 
-  this.enterScope(this.scope.blockScope()); 
+  this.enterScope(this.scope.blockScope());
   var tryBlock = this.parseBlockStatement_dependent('try');
-  this.exitScope(); 
+  this.exitScope();
 
   var finBlock = null, catBlock  = null;
   if (this.lttype === 'Identifier' && this.ltval === 'catch')
@@ -19,9 +19,9 @@ this.parseTryStatement = function () {
 
   if (this.lttype === 'Identifier' && this.ltval === 'finally') {
     this.next();
-    this.enterScope(this.scope.blockScope()); 
+    this.enterScope(this.scope.blockScope());
     finBlock = this.parseBlockStatement_dependent('finally');
-    this.exitScope(); 
+    this.exitScope();
   }
 
   var finOrCat = finBlock || catBlock;

--- a/src/parse-tryblock@Parser.js
+++ b/src/parse-tryblock@Parser.js
@@ -1,4 +1,4 @@
-this.parseTryStatement = function () {
+Parser.prototype.parseTryStatement = function () {
   if ( ! this.ensureStmt_soft () &&
          this.err('not.stmt') )
     return this.errorHandlerOutput ;

--- a/src/parse-unary@Parser.js
+++ b/src/parse-unary@Parser.js
@@ -1,6 +1,6 @@
 this.parseUnaryExpression = function(context) {
   var u = null,
-      startLoc = null,  
+      startLoc = null,
       startc = 0,
       isVDT = this.isVDT;
 
@@ -34,7 +34,7 @@ this.parseUnaryExpression = function(context) {
     this.suspys = n;
     return n;
   }
-  
+
   return {
     type: 'UnaryExpression', operator: u,
     start: startc, end: arg.end,

--- a/src/parse-unary@Parser.js
+++ b/src/parse-unary@Parser.js
@@ -1,4 +1,4 @@
-this.parseUnaryExpression = function(context) {
+Parser.prototype.parseUnaryExpression = function(context) {
   var u = null,
       startLoc = null,
       startc = 0,

--- a/src/parse-var@Parser.js
+++ b/src/parse-var@Parser.js
@@ -31,9 +31,9 @@ this.parseVariableDeclaration = function(context) {
     }
   }
 
-  this.declMode = kind === 'var' ? 
+  this.declMode = kind === 'var' ?
     DM_VAR : DM_LET;
-  
+
   if (kind === 'let' &&
       this.lttype === 'Identifier' &&
       this.ltval === 'in') {
@@ -42,10 +42,10 @@ this.parseVariableDeclaration = function(context) {
 
   elem = this.parseVariableDeclarator(context);
   if (elem === null) {
-    if (kind !== 'let') 
+    if (kind !== 'let')
       this.err('var.has.no.declarators',{extra:[startc,startLoc,context,elem,kind]});
 
-    return null; 
+    return null;
   }
 
   var isConst = kind === 'const';
@@ -70,10 +70,10 @@ this.parseVariableDeclaration = function(context) {
       elem = this.parseVariableDeclarator(context);
       if (!elem)
         this.err('var.has.an.empty.declarator',{extra:[startc,startLoc,context,list,kind]});
-   
+
       if (this.missingInit || (isConst && !elem.init))
         this.err('var.must.have.init',{extra:[startc,startLoc,context,list,kind],elem:elem});
-   
+
       list.push(elem);
     }
   }
@@ -86,8 +86,8 @@ this.parseVariableDeclaration = function(context) {
     endLoc = this.semiLoc_soft();
     if (!endLoc) {
       if (this.nl)
-        endLoc =  lastItem.loc.end; 
-      else  
+        endLoc =  lastItem.loc.end;
+      else
         this.err('no.semi');
     }
   }
@@ -118,7 +118,7 @@ this.parseVariableDeclarator = function(context) {
        this.next();
        init = this.parseNonSeqExpr(PREC_WITH_NO_OP, context|CTX_TOP);
     }
-    else 
+    else
       this.err('var.decl.not.=',{extra:[context,head]});
   }
   else if (head.type !== 'Identifier') { // our pattern is an arr or an obj?
@@ -134,7 +134,7 @@ this.parseVariableDeclarator = function(context) {
     start: head.start, end: initOrHead.end,
     loc: {
       start: head.loc.start,
-      end: initOrHead.loc.end 
+      end: initOrHead.loc.end
     }, init: init && core(init)/* ,y:-1*/
   };
 };

--- a/src/parse-var@Parser.js
+++ b/src/parse-var@Parser.js
@@ -1,4 +1,4 @@
-this.parseVariableDeclaration = function(context) {
+Parser.prototype.parseVariableDeclaration = function(context) {
   if (!this.canBeStatement)
     this.err('not.stmt');
 
@@ -108,7 +108,7 @@ this.parseVariableDeclaration = function(context) {
   };
 };
 
-this.parseVariableDeclarator = function(context) {
+Parser.prototype.parseVariableDeclarator = function(context) {
   var head = this.parsePattern(), init = null;
   if (!head)
     return null;

--- a/src/parse-while@Parser.js
+++ b/src/parse-while@Parser.js
@@ -12,7 +12,7 @@ this.parseWhileStatement = function () {
 
    !this.expectType_soft ('(') &&
    this.err('while.has.no.opening.paren');
- 
+
    var cond = core( this.parseExpr(CTX_NONE|CTX_TOP) );
 
    !this.expectType_soft (')') &&

--- a/src/parse-while@Parser.js
+++ b/src/parse-while@Parser.js
@@ -1,4 +1,4 @@
-this.parseWhileStatement = function () {
+Parser.prototype.parseWhileStatement = function () {
    this.enterScope(this.scope.bodyScope());
    this.allow(SA_BREAK|SA_CONTINUE);
    if (!this.ensureStmt_soft())

--- a/src/parse-with@Parser.js
+++ b/src/parse-with@Parser.js
@@ -1,4 +1,4 @@
-this . parseWithStatement = function() {
+Parser.prototype. parseWithStatement = function() {
    if ( !this.ensureStmt_soft () &&
          this.err('not.stmt') )
      return this.errorHandlerOutput ;

--- a/src/parse-yield@Parser.js
+++ b/src/parse-yield@Parser.js
@@ -1,5 +1,5 @@
 
-this.parseYield = function(context) {
+Parser.prototype.parseYield = function(context) {
   var arg = null,
       deleg = false;
 

--- a/src/parse-yield@Parser.js
+++ b/src/parse-yield@Parser.js
@@ -23,11 +23,11 @@ this.parseYield = function(context) {
   var endI, endLoc;
 
   if ( arg ) { endI = arg.end; endLoc = arg.loc.end; }
-  else { endI = c; endLoc = { line: li, column: col }; }  
+  else { endI = c; endLoc = { line: li, column: col }; }
 
   var n = { type: 'YieldExpression', argument: arg && core(arg), start: startc, delegate: deleg,
            end: endI, loc: { start : startLoc, end: endLoc }/* ,y:-1*/ }
- 
+
   if (this.suspys === null)
     this.suspys = n;
 

--- a/src/precedence.js
+++ b/src/precedence.js
@@ -22,7 +22,7 @@ var PREC_EQUAL = binPrec['==='] =
                  binPrec['!=='] =
                  binPrec['=='] =
                  binPrec['!='] = PREC_BIT_AND + 2;
-var PREC_COMP = binPrec['>'] = 
+var PREC_COMP = binPrec['>'] =
                 binPrec['<='] =
                 binPrec['<'] =
                 binPrec['>='] =

--- a/src/prepare-op@Parser.js
+++ b/src/prepare-op@Parser.js
@@ -8,10 +8,10 @@ this .parseO = function(context ) {
       this.c++ ;
       this.prec = PREC_OP_ASSIG;
       this.ltraw = '/=';
-      this.col++; 
+      this.col++;
     }
     else
-      this.prec = PREC_MUL ; 
+      this.prec = PREC_MUL ;
 
     return true;
 

--- a/src/prepare-op@Parser.js
+++ b/src/prepare-op@Parser.js
@@ -1,4 +1,4 @@
-this .parseO = function(context ) {
+Parser.prototype.parseO = function(context ) {
   switch ( this. lttype ) {
   case 'op': return true;
   case '--': return true;

--- a/src/recv@CatchBodyScope.js
+++ b/src/recv@CatchBodyScope.js
@@ -1,4 +1,4 @@
-this.receiveRef_m = function(mname, ref) {
+CatchBodyScope.prototype.receiveRef_m = function(mname, ref) {
   var decl = this.findDecl_m(mname) ||
     this.catchArgs.findDecl_m(mname);
   if (decl)

--- a/src/recv@CatchHeadScope.js
+++ b/src/recv@CatchHeadScope.js
@@ -1,3 +1,3 @@
-this.recv = function(mname, ref) {
+CatchHeadScope.prototype.recv = function(mname, ref) {
   return this.defaultRecv(mname, ref);
 };

--- a/src/recv@ClassScope.js
+++ b/src/recv@ClassScope.js
@@ -1,4 +1,4 @@
-this.receiveRef_m = function(mname, ref) {
+ClassScope.prototype.receiveRef_m = function(mname, ref) {
   var decl = null;
   this.findRef_m(mname, true).absorb(ref);
 };

--- a/src/recv@FuncBodyScope.js
+++ b/src/recv@FuncBodyScope.js
@@ -1,5 +1,5 @@
 this.receiveRef_m = function(mname, ref) {
-  var decl = 
+  var decl =
     isArguments(mname) ? this.getArguments() :
     isCalledSuper(mname) ? this.getCalledSuper() :
     isMemSuper(mname) ? this.getMemSuper() :

--- a/src/recv@FuncBodyScope.js
+++ b/src/recv@FuncBodyScope.js
@@ -1,4 +1,4 @@
-this.receiveRef_m = function(mname, ref) {
+FuncBodyScope.prototype.receiveRef_m = function(mname, ref) {
   var decl =
     isArguments(mname) ? this.getArguments() :
     isCalledSuper(mname) ? this.getCalledSuper() :

--- a/src/recv@FuncHeadScope.js
+++ b/src/recv@FuncHeadScope.js
@@ -1,3 +1,3 @@
-this.receiveRef_m = function(mname, ref) {
+FuncHeadScope.prototype.receiveRef_m = function(mname, ref) {
   return this.defaultReceive_m(mname, ref);
 };

--- a/src/recv@GlobalScope.js
+++ b/src/recv@GlobalScope.js
@@ -1,10 +1,10 @@
-this.defineGlobal_m = function(mname, ref) {
+GlobalScope.prototype.defineGlobal_m = function(mname, ref) {
   var newDecl = null, globalRef = this.findRef_m(mname, true);
   newDecl = new Decl().r(globalRef).n(_u(mname));
   globalRef.absorb(ref);
   globalRef.resolve();
 };
 
-this.receiveRef_m = function(mname, ref) {
+GlobalScope.prototype.receiveRef_m = function(mname, ref) {
   this.defineGlobal_m(mname, ref);
 };

--- a/src/recv@GlobalScope.js
+++ b/src/recv@GlobalScope.js
@@ -4,7 +4,7 @@ this.defineGlobal_m = function(mname, ref) {
   globalRef.absorb(ref);
   globalRef.resolve();
 };
-  
+
 this.receiveRef_m = function(mname, ref) {
   this.defineGlobal_m(mname, ref);
 };

--- a/src/recv@LexicalScope.js
+++ b/src/recv@LexicalScope.js
@@ -1,3 +1,3 @@
-this.receiveRef_m = function(mname, ref) {
+LexicalScope.prototype.receiveRef_m = function(mname, ref) {
   this.defaultReceive_m(mname, ref);
 };

--- a/src/recv@ParenScope.js
+++ b/src/recv@ParenScope.js
@@ -1,3 +1,3 @@
-this.receiveRef_m = function(mname, ref) {
+ParenScope.prototype.receiveRef_m = function(mname, ref) {
   this.defaultReceive_m(mname, ref);
 };

--- a/src/recv@Scope.js
+++ b/src/recv@Scope.js
@@ -1,11 +1,11 @@
-this.defaultReceive_m = function(mname, ref) {
+Scope.prototype.defaultReceive_m = function(mname, ref) {
   var decl = this.findDecl_m(mname);
   if (decl) decl.absorbRef(ref);
   else
     this.findRef_m(mname, true).absorb(ref);
 };
 
-this.receiveRef_m = function(mname, ref) {
+Scope.prototype.receiveRef_m = function(mname, ref) {
   ASSERT.call(this, this.isScript() || this.isModule(),
     'this scope is supposed to have its own custom ref');
   this.defaultReceive_m(mname, ref);

--- a/src/ref@Scope.js
+++ b/src/ref@Scope.js
@@ -1,4 +1,4 @@
-this.findRef_m = function(mname, createIfNone) {
+Scope.prototype.findRef_m = function(mname, createIfNone) {
   return (
     this.refs.has(mname) ?
     this.refs.get(mname) :
@@ -9,15 +9,15 @@ this.findRef_m = function(mname, createIfNone) {
 
 };
 
-this.findRef = function(name, createIfNone) {
+Scope.prototype.findRef = function(name, createIfNone) {
   return this.findRef_m(_m(name), createIfNone);
 };
 
-this.reference = function(name, prevRef) {
+Scope.prototype.reference = function(name, prevRef) {
   return this.reference_m(_m(name), prevRef);
 };
 
-this.reference_m = function(mname, prevRef) {
+Scope.prototype.reference_m = function(mname, prevRef) {
   var decl = this.findDecl_m(mname);
   if (decl) {
     if (prevRef)

--- a/src/ref@Scope.js
+++ b/src/ref@Scope.js
@@ -1,12 +1,12 @@
 this.findRef_m = function(mname, createIfNone) {
   return (
-    this.refs.has(mname) ? 
+    this.refs.has(mname) ?
     this.refs.get(mname) :
     createIfNone ?
       this.refs.set(mname, new Ref(this)) :
       null
   );
-  
+
 };
 
 this.findRef = function(name, createIfNone) {
@@ -29,7 +29,7 @@ this.reference_m = function(mname, prevRef) {
   }
 
   var ref = this.findRef_m(mname, true);
-  
+
   if (prevRef) ref.absorb(prevRef);
   else ref.direct.fw++;
 

--- a/src/reserved@Emitter.js
+++ b/src/reserved@Emitter.js
@@ -1,1 +1,1 @@
-this.isReserved = function(idString) { return false; };
+Emitter.prototype.isReserved = function(idString) { return false; };

--- a/src/scope@Parser.js
+++ b/src/scope@Parser.js
@@ -1,4 +1,4 @@
-this.declare = function(id) {
+Parser.prototype.declare = function(id) {
    ASSERT.call(this, this.declMode !== DM_NONE, 'Unknown declMode');
    if (this.declMode & (DM_LET|DM_CONST)) {
      if (id.name === 'let')
@@ -8,17 +8,17 @@ this.declare = function(id) {
    this.scope.declare(id.name, this.declMode).s(id);
 };
 
-this.enterScope = function(scope) {
+Parser.prototype.enterScope = function(scope) {
   this.scope = scope;
 };
 
-this.exitScope = function() {
+Parser.prototype.exitScope = function() {
   var scope = this.scope;
   scope.finish();
   this.scope = this.scope.parent;
   return scope;
 };
 
-this.allow = function(allowedActions) {
+Parser.prototype.allow = function(allowedActions) {
   this.scope.allowed |= allowedActions;
 };

--- a/src/semi@Parser.js
+++ b/src/semi@Parser.js
@@ -1,4 +1,4 @@
-this.semiLoc_soft = function () {
+Parser.prototype.semiLoc_soft = function () {
   switch (this.lttype) {
   case ';':
      var n = this.loc();
@@ -16,7 +16,7 @@ this.semiLoc_soft = function () {
   return null;
 };
 
-this.semiI = function() {
+Parser.prototype.semiI = function() {
   switch (this.lttype) {
   case ';':
     return this.c;

--- a/src/semi@Parser.js
+++ b/src/semi@Parser.js
@@ -12,7 +12,7 @@ this.semiLoc_soft = function () {
      if ( !this.nl )
         return this.locOn(1);
   }
-  
+
   return null;
 };
 

--- a/src/show@Decl.js
+++ b/src/show@Decl.js
@@ -1,9 +1,9 @@
-this.str = function() {
+Decl.prototype.str = function() {
   return this.i+':<decl type="'+
          this.typeString()+'">'+this.name+'</decl>';
 };
 
-this.typeString = function() {
+Decl.prototype.typeString = function() {
   var str = "";
 
   if (this.mode & DM_CLS) str += ":class";
@@ -19,6 +19,6 @@ this.typeString = function() {
   return str;
 };
 
-this.writeTo = function(emitter) {
+Decl.prototype.writeTo = function(emitter) {
   emitter.w(this.str());
 };

--- a/src/show@Decl.js
+++ b/src/show@Decl.js
@@ -13,8 +13,8 @@ this.typeString = function() {
   if (this.mode & DM_VAR) str += ":var";
   if (this.mode & DM_CONST) str += ":const";
   if (this.mode & DM_SCOPENAME) str += ":scopename";
-  if (this.mode & DM_CATCHARG) str += ":catcharg"; 
-  if (this.mode & DM_FNARG) str += ":fnarg";  
+  if (this.mode & DM_CATCHARG) str += ":catcharg";
+  if (this.mode & DM_FNARG) str += ":fnarg";
 
   return str;
 };

--- a/src/show@Scope.js
+++ b/src/show@Scope.js
@@ -1,10 +1,10 @@
-this.str = function() {
+Scope.prototype.str = function() {
   var emitter = new Emitter();
   this.writeTo(emitter);
   return emitter.code;
 };
 
-this.typeString = function() {
+Scope.prototype.typeString = function() {
   var str = "";
 
   if (this.type & ST_GLOBAL) str += ":global";
@@ -34,7 +34,7 @@ this.typeString = function() {
   return str;
 };
 
-this.writeTo = function(emitter) {
+Scope.prototype.writeTo = function(emitter) {
   var defs = this.defs,
       scopes = this.ch,
       si = 0,

--- a/src/show@Scope.js
+++ b/src/show@Scope.js
@@ -7,8 +7,8 @@ this.str = function() {
 this.typeString = function() {
   var str = "";
 
-  if (this.type & ST_GLOBAL) str += ":global"; 
-  if (this.type & ST_MODULE) str += ":module"; 
+  if (this.type & ST_GLOBAL) str += ":global";
+  if (this.type & ST_MODULE) str += ":module";
   if (this.type & ST_SCRIPT) str += ":script";
   if (this.type & ST_DECL) str += ":decl";
   if (this.type & ST_CLS) str += ":class";

--- a/src/spawn@GlobalScope.js
+++ b/src/spawn@GlobalScope.js
@@ -1,7 +1,7 @@
-this.moduleScope = function() {
+GlobalScope.prototype.moduleScope = function() {
   return new Scope(this, ST_MODULE);
 };
 
-this.scriptScope = function() {
+GlobalScope.prototype.scriptScope = function() {
   return new Scope(this, ST_SCRIPT);
 };

--- a/src/spawn@Scope.js
+++ b/src/spawn@Scope.js
@@ -1,31 +1,31 @@
-this.clsScope = function(t) {
+Scope.prototype.clsScope = function(t) {
   return new ClassScope(this, t);
 };
 
-this.fnHeadScope = function(t) {
+Scope.prototype.fnHeadScope = function(t) {
   return new FuncHeadScope(this, t);
 };
 
-this.fnBodyScope = function(t) {
+Scope.prototype.fnBodyScope = function(t) {
   return new FuncBodyScope(this, t);
 };
 
-this.blockScope = function() {
+Scope.prototype.blockScope = function() {
   return new LexicalScope(this, ST_BLOCK);
 };
 
-this.catchBodyScope = function() {
+Scope.prototype.catchBodyScope = function() {
   return new CatchBodyScope(this);
 };
 
-this.catchHeadScope = function() {
+Scope.prototype.catchHeadScope = function() {
   return new CatchHeadScope(this);
 };
 
-this.bodyScope = function() {
+Scope.prototype.bodyScope = function() {
   return new LexicalScope(this, ST_BODY);
 };
 
-this.parenScope = function() {
+Scope.prototype.parenScope = function() {
   return new ParenScope(this);
 };

--- a/src/special@FuncBodyScope.js
+++ b/src/special@FuncBodyScope.js
@@ -52,7 +52,7 @@ this.getCalledSuper = function() {
   if (!this.parent.special.scall) {
     var decl = new Decl(),
         ref = this.findRef_m(RS_SCALL, true);
-    this.parent.special.scall = 
+    this.parent.special.scall =
       decl.r(ref).n(_u(RS_MEM));
   }
 

--- a/src/special@FuncBodyScope.js
+++ b/src/special@FuncBodyScope.js
@@ -1,4 +1,4 @@
-this.getArguments = function() {
+FuncBodyScope.prototype.getArguments = function() {
   if (this.isArrowComp())
     return null;
   if (!this.special.arguments) {
@@ -11,7 +11,7 @@ this.getArguments = function() {
   return this.special.arguments;
 };
 
-this.getMemSuper = function() {
+FuncBodyScope.prototype.getMemSuper = function() {
   if (this.isArrowComp())
     return null;
 
@@ -35,7 +35,7 @@ this.getMemSuper = function() {
   return this.parent.special.smem;
 };
 
-this.getCalledSuper = function() {
+FuncBodyScope.prototype.getCalledSuper = function() {
   if (this.isArrowComp())
     return null;
 
@@ -59,7 +59,7 @@ this.getCalledSuper = function() {
   return this.parent.special.scall;
 };
 
-this.getNewTarget = function() {
+FuncBodyScope.prototype.getNewTarget = function() {
   if (this.isArrowComp())
     return null;
 
@@ -73,7 +73,7 @@ this.getNewTarget = function() {
   return this.special.newTarget;
 };
 
-this.getLexicalThis = function() {
+FuncBodyScope.prototype.getLexicalThis = function() {
   if (this.isArrowComp())
     return null;
 

--- a/src/stmt-helpers@Parser.js
+++ b/src/stmt-helpers@Parser.js
@@ -78,9 +78,9 @@ this.gotDirective = function(dv, flags) {
     this.checkForStrictError(flags);
   }
 };
- 
+
 this.clearAllStrictErrors = function() {
   this.esct = ERR_NONE_YET;
   this.se = null;
 };
- 
+

--- a/src/stmt-helpers@Parser.js
+++ b/src/stmt-helpers@Parser.js
@@ -1,9 +1,9 @@
-this . findLabel = function(name) {
+Parser.prototype. findLabel = function(name) {
     return HAS.call(this.labels, name) ?this.labels[name]:null;
 
 };
 
-this .ensureStmt_soft = function() {
+Parser.prototype.ensureStmt_soft = function() {
    if ( this.canBeStatement ) {
      this.canBeStatement = false;
      return true;
@@ -11,18 +11,18 @@ this .ensureStmt_soft = function() {
    return false;
 };
 
-this . fixupLabels = function(loop) {
+Parser.prototype. fixupLabels = function(loop) {
     if ( this.unsatisfiedLabel ) {
          this.unsatisfiedLabel.loop = loop;
          this.unsatisfiedLabel = null;
     }
 };
 
-this.enterCatchScope = function() {
+Parser.prototype.enterCatchScope = function() {
   this.scope = this.scope.spawnCatch();
 };
 
-this.blck = function () { // blck ([]stmt)
+Parser.prototype.blck = function () { // blck ([]stmt)
   var isFunc = false, stmt = null, stmts = [];
   if (this.directive !== DIR_NONE)
     this.parseDirectives(stmts);
@@ -33,12 +33,12 @@ this.blck = function () { // blck ([]stmt)
   return (stmts);
 };
 
-this.checkForStrictError = function(directive) {
+Parser.prototype.checkForStrictError = function(directive) {
   if (this.esct !== ERR_NONE_YET)
     this.err('strict.err.esc.not.valid');
 };
 
-this.parseDirectives = function(list) {
+Parser.prototype.parseDirectives = function(list) {
   if (this.v < 5)
     return;
 
@@ -69,7 +69,7 @@ this.parseDirectives = function(list) {
   this.directive = DIR_NONE;
 };
 
-this.gotDirective = function(dv, flags) {
+Parser.prototype.gotDirective = function(dv, flags) {
   if (dv.raw === 'use strict') {
     this.scope.enterStrict();
     if (flags & DIR_FUNC)
@@ -79,7 +79,7 @@ this.gotDirective = function(dv, flags) {
   }
 };
 
-this.clearAllStrictErrors = function() {
+Parser.prototype.clearAllStrictErrors = function() {
   this.esct = ERR_NONE_YET;
   this.se = null;
 };

--- a/src/synth-nodes.js
+++ b/src/synth-nodes.js
@@ -18,12 +18,12 @@ function assig_node(left, right) {
    if (left.type === 'Identifier' && right.type === 'Identifier')
      if (left.synth && left.name === right.name )
        return left;
-  
+
    return { type: 'AssignmentExpression',  operator: '=', right: right, left: left, y: 0 };
 }
 
 function cond_node(e, c, a) {
-   return { type: 'ConditionalExpression', 
+   return { type: 'ConditionalExpression',
             test: e,
             consequent: c,
             alternate: a,
@@ -62,7 +62,7 @@ function synth_if_node(cond, body, alternate, yBody, yElse) {
 
   return { type: 'IfStatement',
            alternate: alternate ,
-           consequent: body, 
+           consequent: body,
            test: cond, y: yBody + yElse };
 }
 
@@ -73,7 +73,7 @@ function append_assig(b, left, right) {
 
   if ( assig ) b.push(assig);
 }
-   
+
 function append_non_synth(b, nexpr) {
   if (nexpr.type !== 'Identifier' || !nexpr.synth )
     b. push(nexpr);
@@ -84,7 +84,7 @@ function synth_mem_node(obj, prop, c) {
   return { type: 'MemberExpression',
            computed: c,
            object: obj,
-           property: (prop),  
+           property: (prop),
            y: 0 };
 
 }
@@ -102,17 +102,17 @@ function call_call(thisObj, callee, argList) {
       [synth_id_node(thisObj)].concat(argList)
    );
 }
- 
+
 function synth_literal_node(value) {
    return { type: 'Literal', value: value };
 }
 
 function synth_binexpr(left, o, right, yc) {
    var t = "";
-   if ( o === '||' || o === '&&' ) t = 'LogicalExpression'; 
+   if ( o === '||' || o === '&&' ) t = 'LogicalExpression';
    else if ( o.charAt(o.length-1) === '=' ) switch (o) {
       case '==':
-      case '>=': 
+      case '>=':
       case '<=':
       case '!=':
       case '!==':
@@ -124,12 +124,12 @@ function synth_binexpr(left, o, right, yc) {
         t = 'AssignmentExpression';
         break;
    }
-   else t = 'BinaryExpression';  
-    
+   else t = 'BinaryExpression';
+
    return {
      type: t,
      left: left,
-     y: yc, 
+     y: yc,
      right: right,
      operator: o
    };

--- a/src/synth-utils.js
+++ b/src/synth-utils.js
@@ -1,5 +1,5 @@
-function synth_id(name) { 
-  return { type: 'Identifier', name: name }; 
+function synth_id(name) {
+  return { type: 'Identifier', name: name };
 }
 
 function synth_assig(left, right, o) {
@@ -28,7 +28,7 @@ function synth_call(callee, args) {
 function synth_stmt(stmts) {
   return stmts.lenght === 1 ? stmts[0] : synth_block_stmt(stmts);
 }
- 
+
 function synth_block_stmt(body) {
   return { type: 'BlockStatement', body: body, y: -1 };
 }
@@ -37,7 +37,7 @@ function synth_block_stmt(body) {
 function synth_if(cond, c, a) {
   return { type: 'IfStatement', consequent: synth_stmt(c), y: -1, test: cond, alternate: a && a.length ? synth_stmt(a) : null };
 }
- 
+
 function synth_cond(cond, c, a) {
   return { type: 'ConditionalExpression', consequent: c, y: -1, test: cond, alternate: a };
 }

--- a/src/transform-assig@Transformer.js
+++ b/src/transform-assig@Transformer.js
@@ -38,7 +38,7 @@ transform['AssignmentExpression'] = function(n, list, isVal) {
 // the temp it is saved in.
 // observation: if there are no temps needed for its right, the element need not be saved
 var evalLeft = {};
-this.evalLeft = function(left, right, list) {
+Transformer.prototype.evalLeft = function(left, right, list) {
   return evalLeft[left.type].call(this, left, right, list);
 };
 
@@ -73,11 +73,11 @@ transformAssig['MemberExpression'] = function(n, list, isVal) {
 };
 
 var assigPattern = {};
-this.assigPattern = function(left, right, list) {
+Transformer.prototype.assigPattern = function(left, right, list) {
   return assigPattern[left.type].call(this, left, right, list);
 };
 
-this.evalProp = function(elem, list) {
+Transformer.prototype.evalProp = function(elem, list) {
   if (elem.computed) {
     elem.key = this.tr(elem.key, list, true);
     elem.key = this.save(elem.key, list);

--- a/src/transform-assig@Transformer.js
+++ b/src/transform-assig@Transformer.js
@@ -24,7 +24,7 @@ transform['AssignmentExpression'] = function(n, list, isVal) {
     else push_if_assig(tr, list);
     return synth_seq(list, isVal);
   }
-  
+
   return tr;
 };
 
@@ -35,7 +35,7 @@ transform['AssignmentExpression'] = function(n, list, isVal) {
 // generally speaking, an 'occupySent' should exist, and should be used by any expression
 // that makes use of sent; each call to this hypothetical 'occupySent' will then return 'sent',
 // saving the current expression that is using 'sent' in a temp, and further replacing that expression with
-// the temp it is saved in. 
+// the temp it is saved in.
 // observation: if there are no temps needed for its right, the element need not be saved
 var evalLeft = {};
 this.evalLeft = function(left, right, list) {
@@ -65,7 +65,7 @@ evalLeft['MemberExpression'] = function(left, right, list) {
 transformAssig['MemberExpression'] = function(n, list, isVal) {
   var left = n.left;
   n.right = this.tr(n.right, list, true);
-  
+
   // `a()[b()] = (yield a()) * (yield)`, you know
   this.rlit(left.property);
   this.rlit(left.object);
@@ -84,13 +84,13 @@ this.evalProp = function(elem, list) {
   }
   this.evalLeft(elem.value, null, list);
 };
- 
+
 evalLeft['ObjectPattern'] = function(left, right, list) {
   var elems = left.properties, e = 0;
   while (e < elems.length)
     this.evalProp(elems[e++], list);
 };
- 
+
 assigPattern['ObjectPattern'] = function(left, right, list) {
   var elems = left.properties, e = 0;
   while (e < elems.length) {
@@ -142,7 +142,7 @@ transformAssig['ArrayPattern'] = function(n, list, isVal) {
   this.assigPattern(n.left, iter, list);
   this.rl(iter);
   return isVal ? iterVal(iter) : NOEXPR;
-}; 
+};
 
 evalLeft['AssignmentPattern'] = function(left, right, list) {
   return this.evalLeft(left.left, right, list);

--- a/src/transform-cond@Transformer.js
+++ b/src/transform-cond@Transformer.js
@@ -8,7 +8,7 @@ transform['ConditionalExpression'] = function(n, list, isVal) {
   return n;
 };
 
-this.transformConditionalExpressionWithYield = function(n, list, isVal) {
+Transformer.prototype.transformConditionalExpressionWithYield = function(n, list, isVal) {
   n.test = this.transform(n.test, list, true);
   var ifBody = [], elseBody = [];
       t = null;

--- a/src/transform-function@Transformer.js
+++ b/src/transform-function@Transformer.js
@@ -10,7 +10,7 @@ transform['FunctionDeclaration'] = function(n, pushTarget, isVal) {
   return n;
 };
 
-this.addParamAssigPrologueToBody = function(fn) {
+Transformer.prototype.addParamAssigPrologueToBody = function(fn) {
   var prolog = {
     type: 'ArgsPrologue',
     left: fn.params,

--- a/src/transform-if@Transformer.js
+++ b/src/transform-if@Transformer.js
@@ -1,7 +1,7 @@
 transform['IfStatement'] = function(n, pushTarget, isVal) {
   if (this.y(n))
     return this.transformIfStatementWithYield(n, pushTarget, isVal);
-  
+
   n.test = this.tr(n.test, null, true);
   n.consequent = this.tr(n.consequent, null, false);
   if (n.alternate)

--- a/src/transform-logical-expr@Transformer.js
+++ b/src/transform-logical-expr@Transformer.js
@@ -13,7 +13,7 @@ this.transformLogicalExpressionWithYield = function(n, list, isVal) {
     t = this.allocTemp();
     n.left = synth_assig(t, n.left);
     if (n.operator === '||')
-      n.left = synth_not(n.left); 
+      n.left = synth_not(n.left);
     this.rl(t);
   }
   var tr = this.tr(n.right, ifBody, isVal);

--- a/src/transform-logical-expr@Transformer.js
+++ b/src/transform-logical-expr@Transformer.js
@@ -6,7 +6,7 @@ transform['LogicalExpression'] = function(n, list, isVal) {
   return n;
 };
 
-this.transformLogicalExpressionWithYield = function(n, list, isVal) {
+Transformer.prototype.transformLogicalExpressionWithYield = function(n, list, isVal) {
   var ifBody = [],
       t = null;
   if (isVal) {

--- a/src/transform-utils.js
+++ b/src/transform-utils.js
@@ -1,5 +1,5 @@
 function sentVal() {
-  return specialId('sentVal'); 
+  return specialId('sentVal');
 }
 function isSentVal(id) {
   return isspecial(id, 'sentVal');
@@ -64,7 +64,7 @@ function push_checked(n, list) {
 }
 
 function push_if_assig(n, list) {
-  if (n && 
+  if (n &&
     ( n.type === 'AssignmentExpression' || n.type === 'SyntheticAssignment' ) )
     list.push(n);
 }
@@ -74,6 +74,6 @@ function functionHasNonSimpleParams(fn) {
   while (i < list.length)
     if (list[i++].type !== 'Identifier')
       return true;
-  
+
   return false;
 }

--- a/src/util.js
+++ b/src/util.js
@@ -10,7 +10,7 @@ function hex(number) {
   str = hexD[(number>>=4)&0xf] + str ;
   str = hexD[(number>>=4)&0xf] + str ;
   str = hexD[(number>>=4)&0xf] + str ;
-  
+
   return str;
 }
 
@@ -18,7 +18,7 @@ function hex2(number) {
   var str = "";
   str = hexD[number&0xf] + str
   str = hexD[(number>>=4)&0xf] + str ;
-  
+
   return str;
 }
 

--- a/src/util@Scope.js
+++ b/src/util@Scope.js
@@ -1,60 +1,60 @@
 // function component: function head or function body
-this.isGlobal = function() { return this.type & ST_GLOBAL; };
-this.isModule = function() { return this.type & ST_MODULE; };
-this.isScript = function() { return this.type & ST_SCRIPT; };
-this.isDecl = function() { return this.type & ST_DECL; };
-this.isClass = function() { return this.type & ST_CLS; };
-this.isAnyFnComp = function() { return this.type & ST_ANY_FN; };
-this.isAnyFnHead = function() {
+Scope.prototype.isGlobal = function() { return this.type & ST_GLOBAL; };
+Scope.prototype.isModule = function() { return this.type & ST_MODULE; };
+Scope.prototype.isScript = function() { return this.type & ST_SCRIPT; };
+Scope.prototype.isDecl = function() { return this.type & ST_DECL; };
+Scope.prototype.isClass = function() { return this.type & ST_CLS; };
+Scope.prototype.isAnyFnComp = function() { return this.type & ST_ANY_FN; };
+Scope.prototype.isAnyFnHead = function() {
   return this.isAnyFnComp() && this.isHead();
 };
-this.isAnyFnBody = function() {
+Scope.prototype.isAnyFnBody = function() {
   return this.isAnyFnComp() && this.isBody();
 };
-this.isClassMem = function() { return this.type & ST_CLSMEM; };
-this.isGetterComp = function() { return this.type & ST_GETTER; };
-this.isSetterComp = function() { return this.type & ST_SETTER; };
-this.isStaticMem = function() { return this.type & ST_STATICMEM; };
-this.isCtorComp = function() { return this.type & ST_CTOR; };
-this.isObjMem = function() { return this.type & ST_OBJMEM; };
-this.isArrowComp = function() { return this.type & ST_ARROW; };
-this.isBlock = function() { return this.type & ST_BLOCK; };
-this.isCatchComp = function() { return this.type & ST_CATCH; };
-this.isBody = function() { return this.type & ST_BODY; };
-this.isMethComp = function() { return this.type & ST_METH; };
-this.isExpr = function() { return this.type & ST_EXPR; };
-this.isMem = function() { return this.isStaticMem() || this.isClassMem() || this.isObjMem(); };
-this.isGenComp = function() { return this.type & ST_GEN; };
-this.isAsyncComp = function() { return this.type & ST_ASYNC; };
-this.isAccessorComp = function() { return this.isGetterComp() || this.isSetterComp(); };
-this.isSpecialComp = function() { return this.isAccessorComp() || this.isGenComp(); };
-this.isLexical = function() { return this.isCatchBody() || this.isBlock(); };
-this.isTopLevel = function() { return this.type & ST_TOP; };
-this.isHoistable = function() { return this.isSimpleFnComp() && this.isDecl(); };
-this.isIndirect = function() { return this.isAnyFnComp() || this.isClass(); };
-this.isConcrete = function() { return this.type & ST_CONCRETE; };
-this.isSimpleFnComp = function() { return this.type & ST_FN; };
-this.isBare = function() { return this.isBody() && !(this.isLexical() || this.isAnyFnComp()); };
-this.isCatchBody = function() { return this.isCatchComp() && this.isBody(); };
-this.isCatchHead = function() { return this.isCatchComp() && this.isHead(); };
-this.isHead = function() { return this.type & ST_HEAD; };
-this.isParen = function() { return this.type & ST_PAREN; };
+Scope.prototype.isClassMem = function() { return this.type & ST_CLSMEM; };
+Scope.prototype.isGetterComp = function() { return this.type & ST_GETTER; };
+Scope.prototype.isSetterComp = function() { return this.type & ST_SETTER; };
+Scope.prototype.isStaticMem = function() { return this.type & ST_STATICMEM; };
+Scope.prototype.isCtorComp = function() { return this.type & ST_CTOR; };
+Scope.prototype.isObjMem = function() { return this.type & ST_OBJMEM; };
+Scope.prototype.isArrowComp = function() { return this.type & ST_ARROW; };
+Scope.prototype.isBlock = function() { return this.type & ST_BLOCK; };
+Scope.prototype.isCatchComp = function() { return this.type & ST_CATCH; };
+Scope.prototype.isBody = function() { return this.type & ST_BODY; };
+Scope.prototype.isMethComp = function() { return this.type & ST_METH; };
+Scope.prototype.isExpr = function() { return this.type & ST_EXPR; };
+Scope.prototype.isMem = function() { return this.isStaticMem() || this.isClassMem() || this.isObjMem(); };
+Scope.prototype.isGenComp = function() { return this.type & ST_GEN; };
+Scope.prototype.isAsyncComp = function() { return this.type & ST_ASYNC; };
+Scope.prototype.isAccessorComp = function() { return this.isGetterComp() || this.isSetterComp(); };
+Scope.prototype.isSpecialComp = function() { return this.isAccessorComp() || this.isGenComp(); };
+Scope.prototype.isLexical = function() { return this.isCatchBody() || this.isBlock(); };
+Scope.prototype.isTopLevel = function() { return this.type & ST_TOP; };
+Scope.prototype.isHoistable = function() { return this.isSimpleFnComp() && this.isDecl(); };
+Scope.prototype.isIndirect = function() { return this.isAnyFnComp() || this.isClass(); };
+Scope.prototype.isConcrete = function() { return this.type & ST_CONCRETE; };
+Scope.prototype.isSimpleFnComp = function() { return this.type & ST_FN; };
+Scope.prototype.isBare = function() { return this.isBody() && !(this.isLexical() || this.isAnyFnComp()); };
+Scope.prototype.isCatchBody = function() { return this.isCatchComp() && this.isBody(); };
+Scope.prototype.isCatchHead = function() { return this.isCatchComp() && this.isHead(); };
+Scope.prototype.isHead = function() { return this.type & ST_HEAD; };
+Scope.prototype.isParen = function() { return this.type & ST_PAREN; };
 
-this.insideIf = function() { return this.mode & SM_INSIDE_IF; };
-this.insideLoop = function() { return this.mode & SM_LOOP; };
-this.insideStrict = function() { return this.mode & SM_STRICT; };
-this.insideBlock = function() { return this.mode & SM_BLOCK; };
-this.insideFuncArgs = function() { return this.mode & SM_INARGS; };
-this.insideForInit = function() { return this.mode & SM_FOR_INIT; };
-this.insideUniqueArgs = function() { return this.mode & SM_UNIQUE; };
+Scope.prototype.insideIf = function() { return this.mode & SM_INSIDE_IF; };
+Scope.prototype.insideLoop = function() { return this.mode & SM_LOOP; };
+Scope.prototype.insideStrict = function() { return this.mode & SM_STRICT; };
+Scope.prototype.insideBlock = function() { return this.mode & SM_BLOCK; };
+Scope.prototype.insideFuncArgs = function() { return this.mode & SM_INARGS; };
+Scope.prototype.insideForInit = function() { return this.mode & SM_FOR_INIT; };
+Scope.prototype.insideUniqueArgs = function() { return this.mode & SM_UNIQUE; };
 
-this.canReturn = function() { return this.allowed & SA_RETURN; };
-this.canContinue = function() { return this.allowed & SA_CONTINUE; };
-this.canBreak = function() { return this.allowed & SA_BREAK; };
-this.canDeclareLetOrClass = function() {
+Scope.prototype.canReturn = function() { return this.allowed & SA_RETURN; };
+Scope.prototype.canContinue = function() { return this.allowed & SA_CONTINUE; };
+Scope.prototype.canBreak = function() { return this.allowed & SA_BREAK; };
+Scope.prototype.canDeclareLetOrClass = function() {
   return this.isAnyFnBody() || this.isTopLevel() || this.isLexical() || this.insideForInit();
 };
-this.canDeclareFunc = function() {
+Scope.prototype.canDeclareFunc = function() {
   if (this.insideStrict())
     return false;
 
@@ -64,27 +64,27 @@ this.canDeclareFunc = function() {
          this.insideIf();
 };
 
-this.canYield = function() { return this.allowed & SA_YIELD; };
-this.canAwait = function() { return this.allowed & SA_AWAIT; };
-this.canSupCall = function() {
+Scope.prototype.canYield = function() { return this.allowed & SA_YIELD; };
+Scope.prototype.canAwait = function() { return this.allowed & SA_AWAIT; };
+Scope.prototype.canSupCall = function() {
   return this.isArrowComp() ?
     this.parent.canSupCall() :
     this.allowed & SA_CALLSUP
 };
 
-this.canSupMem = function() {
+Scope.prototype.canSupMem = function() {
   return this.isArrowComp() ?
     this.parent.canSupMem() :
     this.allowed & SA_MEMSUP;
 };
 
-this.canHaveNewTarget = function() {
+Scope.prototype.canHaveNewTarget = function() {
    return this.isArrowComp() ?
      this.parent.canHaveNewTarget() :
      this.isAnyFnComp();
 };
 
-this.canDup = function() {
+Scope.prototype.canDup = function() {
   ASSERT.call(this, this.insideFuncArgs(),
     'it has no meaning to call canDup when not ' +
     'in func-arguments');
@@ -92,34 +92,34 @@ this.canDup = function() {
          !this.insideUniqueArgs();
 };
 
-this.enterForInit = function() {
+Scope.prototype.enterForInit = function() {
   ASSERT.call(this, this.isBare(),
     'to enter for init mode, the scope has to be a bare one');
 
   this.mode |= SM_FOR_INIT;
 };
 
-this.exitForInit = function() {
+Scope.prototype.exitForInit = function() {
   ASSERT.call(this, this.insideForInit(),
     'can not unset the for-init mode when it is not set');
 
   this.mode &= ~SM_FOR_INIT;
 };
 
-this.enterStrict = function() {
+Scope.prototype.enterStrict = function() {
   this.mode |= SM_STRICT;
 };
 
-this.exitStrict = function() {
+Scope.prototype.exitStrict = function() {
   ASSERT.call(this, this.insideStrict(),
     'can not unset strict when it is not set');
   this.mode &= ~SM_STRICT;
 };
 
-this.yieldIsKW = function() { return this.mode & SM_YIELD_KW; };
-this.awaitIsKW = function() { return this.mode & SM_AWAIT_KW; };
+Scope.prototype.yieldIsKW = function() { return this.mode & SM_YIELD_KW; };
+Scope.prototype.awaitIsKW = function() { return this.mode & SM_AWAIT_KW; };
 
-this.hasHeritage = function() {
+Scope.prototype.hasHeritage = function() {
   ASSERT.call(this, this.isClass(),
     'only classes are allowed to be tested for '+
     'heritage');

--- a/src/util@Scope.js
+++ b/src/util@Scope.js
@@ -69,7 +69,7 @@ this.canAwait = function() { return this.allowed & SA_AWAIT; };
 this.canSupCall = function() {
   return this.isArrowComp() ?
     this.parent.canSupCall() :
-    this.allowed & SA_CALLSUP 
+    this.allowed & SA_CALLSUP
 };
 
 this.canSupMem = function() {
@@ -95,7 +95,7 @@ this.canDup = function() {
 this.enterForInit = function() {
   ASSERT.call(this, this.isBare(),
     'to enter for init mode, the scope has to be a bare one');
-  
+
   this.mode |= SM_FOR_INIT;
 };
 

--- a/src/validate@Parser.js
+++ b/src/validate@Parser.js
@@ -9,7 +9,7 @@ this .validateID  = function (e) {
          case 'do':
          case 'if':
          case 'in':
-            
+
             return this.errorReservedID(e);
          default: break SWITCH;
      }
@@ -53,14 +53,14 @@ this .validateID  = function (e) {
          case 'short':
             if ( this. v > 5 ) break SWITCH;
             return this.errorReservedID(e);
-    
-         case 'yield': 
+
+         case 'yield':
             if (!this.scope.insideStrict() && !this.scope.canYield() && !this.scope.yieldIsKW()) {
               break SWITCH;
             }
 
          case 'break': case 'catch': case 'class': case 'const': case 'false':
-         case 'super': case 'throw': case 'while': 
+         case 'super': case 'throw': case 'while':
             return this.errorReservedID(e);
 
          default: break SWITCH;
@@ -69,7 +69,7 @@ this .validateID  = function (e) {
          case 'double': case 'native': case 'throws':
              if ( this. v > 5 )
                 break SWITCH;
-             return this.errorReservedID(e); 
+             return this.errorReservedID(e);
          case 'public':
          case 'static':
              if ( this.v > 5 && !this.scope.insideStrict() )

--- a/src/validate@Parser.js
+++ b/src/validate@Parser.js
@@ -1,4 +1,4 @@
-this .validateID  = function (e) {
+Parser.prototype.validateID  = function (e) {
   var n = e === "" ? this.ltval : e;
 
   SWITCH:
@@ -132,7 +132,7 @@ this .validateID  = function (e) {
   return e ? null : this.id();
 };
 
-this.errorReservedID = function(id) {
+Parser.prototype.errorReservedID = function(id) {
   this.resvchk();
   if ( !this.throwReserved ) {
      this.throwReserved = true;


### PR DESCRIPTION
This PR addresses the problems described in the issue #18.

Submodules now define the methods directly on the object's protoype.
This means that a module could be built by simply concatenating its parts without any additional effort.

Notes:
 - the builder has remained unchanged and I wouldn't close the issue until it has been reworked
 - the changes have been applied using the following script (a brief description of it's functioning is found in the commit message)
```zsh
for file in src/*.js; do
	sfile=(${(s:@:)file:t})
	if [[ ! -z "$sfile[2]" ]]; then
		module_name=${sfile[2]//.js/}
		sed -ie "s/^this\s*\./${module_name}.prototype./g" "$file"
		echo "$sfile[2] > $sfile[1]"
	fi
done
```